### PR TITLE
Remove failing JS linting

### DIFF
--- a/script/test
+++ b/script/test
@@ -20,14 +20,6 @@ if [ -n "$TEST_FILE" ]; then
   echo "==> Running the tests matching '$TEST_FILE'..."
   bundle exec rspec --pattern "$TEST_FILE"
 else
-  if [ -n "$CI" ]; then
-    echo "==> Checking formatting..."
-    yarn run lint:format
-  else
-    echo "==> Formatting files..."
-    yarn run lint:format:fix
-  fi
-
   echo "==> Running ShellCheck..."
   shellcheck script/*
 
@@ -37,14 +29,6 @@ else
   else
     echo "==> Linting Ruby in fix mode..."
     bundle exec standardrb --fix
-  fi
-
-  if [ -n "$CI" ]; then
-    echo "==> Linting JS..."
-    yarn run lint:js
-  else
-    echo "==> Linting JS in fix mode..."
-    yarn run lint:js:fix
   fi
 
   echo "==> Running the tests..."


### PR DESCRIPTION
When I run this I get the following error:

```
yarn run v1.22.4
error Command "lint:format" not found.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

On inspection `lint` can receive a file or filepath but not a `:format`. On looking at the package, the one I can find doesn't appear to have this type of interface https://classic.yarnpkg.com/en/package/lint

As we don't have JS to lint at the moment I'm removing the JS linting for now to unblock progress. I have raised the issue on the pull request of these scripts into the rails-template itself in the hope we can address them centrally https://github.com/dxw/rails-template/pull/113#issuecomment-676210194
