### PR TITLE
Switch from Firefox to Chrome for feature tests that need JS

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -4,5 +4,4 @@ brew "mongodb-community@4.4"
 brew "rbenv"
 brew "yarn"
 
-cask "firefox"
-brew "geckodriver"
+cask "chromedriver"

--- a/Brewfile.lock.json
+++ b/Brewfile.lock.json
@@ -2,7 +2,7 @@
   "entries": {
     "tap": {
       "mongodb/brew": {
-        "revision": "0884e0f5b64834a8bd44dcd4df162aff3bbf80b9"
+        "revision": "1ec52e55b8d66cac398497d9643cf475df842e64"
       }
     },
     "brew": {
@@ -35,34 +35,13 @@
       "yarn": {
         "version": "1.22.5",
         "bottle": false
-      },
-      "geckodriver": {
-        "version": "0.27.0",
-        "bottle": {
-          "cellar": ":any_skip_relocation",
-          "prefix": "/usr/local",
-          "files": {
-            "catalina": {
-              "url": "https://homebrew.bintray.com/bottles/geckodriver-0.27.0.catalina.bottle.tar.gz",
-              "sha256": "bd5e9db1c72e65e9af516a5c8bc43c8896808b636b036b1467447418cb34a235"
-            },
-            "mojave": {
-              "url": "https://homebrew.bintray.com/bottles/geckodriver-0.27.0.mojave.bottle.tar.gz",
-              "sha256": "d4d308dede5f3762694b6da1d21426e470bc8973b8e0084e1a44272b9673204d"
-            },
-            "high_sierra": {
-              "url": "https://homebrew.bintray.com/bottles/geckodriver-0.27.0.high_sierra.bottle.tar.gz",
-              "sha256": "c1ccd105a99db9ad2cdbba28d2502ff3a215479e83248b419c44799c0ee68dec"
-            }
-          }
-        }
       }
     },
     "cask": {
-      "firefox": {
-        "version": "80.0.1",
+      "chromedriver": {
+        "version": "85.0.4183.87",
         "options": {
-          "full_name": "firefox"
+          "full_name": "chromedriver"
         }
       }
     }
@@ -72,7 +51,7 @@
       "catalina": {
         "HOMEBREW_VERSION": "2.5.1",
         "HOMEBREW_PREFIX": "/usr/local",
-        "Homebrew/homebrew-core": "740bb171e701991b80e449c6856874bf8e295bf2",
+        "Homebrew/homebrew-core": "17d690f7eca4e529f022b45b9ce9ba4effaa0009",
         "CLT": "1103.0.32.62",
         "Xcode": "11.5",
         "macOS": "10.15.6"

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -2,6 +2,10 @@
 
 require "selenium/webdriver"
 
+javascript_driver = ENV["CI"].present? ? :selenium_headless : :selenium_chrome_headless
+
 Capybara.asset_host = "http://localhost:3000"
-Capybara.javascript_driver = :selenium_headless
+Capybara.always_include_port = true
+Capybara.default_driver = :rack_test
+Capybara.javascript_driver = javascript_driver
 Capybara.server = :puma, {Silent: true}


### PR DESCRIPTION
CI uses Firefox whilst dev uses Chrome for browser tests

Firefox was working on CI but I missed the fact that it started breaking outside of docker.

The error included Geckodriver in the middle of several chrome references. Odd since I thought the `selenium_headless` driver was Firefox by default [1].

```
  Failure/Error: Unable to find WebDriverError@chrome://marionette/content/error.js to read failed line

     Selenium::WebDriver::Error::InvalidArgumentError:
       Expected "handle" to be a string, got [object Undefined] undefined
     # WebDriverError@chrome://marionette/content/error.js:175:5
     # InvalidArgumentError@chrome://marionette/content/error.js:304:5
     # assert.that/<@chrome://marionette/content/assert.js:479:13
     # assert.string@chrome://marionette/content/assert.js:383:53
     # GeckoDriver.prototype.switchToWindow@chrome://marionette/content/driver.js:1645:10
     # despatch@chrome://marionette/content/server.js:305:40
     # execute@chrome://marionette/content/server.js:275:16
     # onPacket/<@chrome://marionette/content/server.js:248:20
     # onPacket@chrome://marionette/content/server.js:249:9
     # _onJSONObjectReady/<@chrome://marionette/content/transport.js:501:20
```

[1] https://github.com/teamcapybara/capybara#selenium

chromium-chromedriver is not available in the debian packages so I cannot figure out how to get chrome running on CI. Given I've been stuck on this for a time I'm going to leave it with Chrome for dev and Firefox for CI. The driver should be interchangeable from Capybara's point of view. Docker tests can always be run locally too if a problem with parity comes up.