### PR TITLE
Infrastructure list is not full width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - users can update an existing environment variable
 - users can delete existing environment variables
 - environment variables are displayed on their own tab
+- infrastructure list is not longer full width
 
 [unreleased]: TODO
 [keep a changelog 1.0.0]: https://keepachangelog.com/en/1.0.0/

--- a/app/views/infrastructures/index.html.erb
+++ b/app/views/infrastructures/index.html.erb
@@ -1,12 +1,14 @@
-<h1 class="mt-5">
-  <%= I18n.t("page_title.infrastructures") %>
-</h1>
+<div class="col-6 offset-3">
+  <h1 class="mt-5">
+    <%= I18n.t("page_title.infrastructures") %>
+  </h1>
 
-<ul class="list-group">
-  <% @infrastructures.each do |infrastructure| %>
-    <li class="list-group-item" id=<%= infrastructure.id %>>
-      <%= infrastructure.identifier %>
-      <%= link_to "View", infrastructure_path(infrastructure), class: "btn btn-primary float-right", role: "button" %>
-    </li>
-  <% end %>
-</ul>
+  <ul class="list-group">
+    <% @infrastructures.each do |infrastructure| %>
+      <li class="list-group-item" id=<%= infrastructure.id %>>
+        <%= infrastructure.identifier %>
+        <%= link_to "View", infrastructure_path(infrastructure), class: "btn btn-primary float-right", role: "button" %>
+      </li>
+    <% end %>
+  </ul>
+</div>


### PR DESCRIPTION
## Changes in this PR

This content is currently stretched to full width by the default layout. While this is great for tabular information it isn't great for a simple list like this. Let's reduce the width to make it easier to click "View" for the intended infrastructure.

## Screenshots of UI changes

### Before

![Screenshot 2020-09-16 at 12 00 31](https://user-images.githubusercontent.com/912473/93329065-899ca400-f814-11ea-84a0-8114967656c2.png)

### After

![Screenshot 2020-09-16 at 12 00 21](https://user-images.githubusercontent.com/912473/93329071-8c979480-f814-11ea-9fdf-792443e3e1c6.png)
