### PR TITLE
Report test coverage of main branch

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: pull_request
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   test:


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

Coveralls is not recieving test status for the main branch, only for pull request branches. Whilst this is great for feedback during CI it means we have no status for `main` to display in the readme badge.
