### PR TITLE
Users can see infrastructure variables for each environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - users can delete existing environment variables
 - environment variables are displayed on their own tab
 - infrastructure list is not longer full width
+- users can see infrastructure variables as well as environment variables for a given infrastructure
 
 [unreleased]: TODO
 [keep a changelog 1.0.0]: https://keepachangelog.com/en/1.0.0/

--- a/Gemfile
+++ b/Gemfile
@@ -25,23 +25,24 @@ gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
 gem "uglifier", ">= 1.3.0"
 
 group :development do
+  gem "better_errors"
   gem "listen", ">= 3.0.5", "< 3.3"
+  gem "html2haml"
+  gem "rails_layout"
   gem "spring"
+  gem "spring-commands-rspec"
   gem "spring-watcher-listen", "~> 2.0.0"
   gem "web-console", ">= 3.3.0"
 end
 
 group :test do
   gem "capybara", ">= 2.15"
+  gem "database_cleaner"
+  gem "launchy"
   gem "geckodriver-helper"
   gem "selenium-webdriver"
-end
-
-group :development do
-  gem "better_errors"
-  gem "html2haml"
-  gem "rails_layout"
-  gem "spring-commands-rspec"
+  gem "simplecov", "~> 0.18"
+  gem "simplecov-lcov"
 end
 
 group :development, :test do
@@ -54,11 +55,4 @@ group :development, :test do
   gem "pry"
   gem "rspec-rails"
   gem "standard"
-end
-
-group :test do
-  gem "database_cleaner"
-  gem "launchy"
-  gem "simplecov", "~> 0.18"
-  gem "simplecov-lcov"
 end

--- a/app/controllers/environment_variables_controller.rb
+++ b/app/controllers/environment_variables_controller.rb
@@ -50,12 +50,4 @@ class EnvironmentVariablesController < ApplicationController
   def environment_variable_params
     params.require("environment_variable").permit(:name, :value, :service_name, :environment_name)
   end
-
-  def name
-    environment_variable_params[:name]
-  end
-
-  def value
-    environment_variable_params[:value]
-  end
 end

--- a/app/controllers/infrastructure_variables_controller.rb
+++ b/app/controllers/infrastructure_variables_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class InfrastructureVariablesController < ApplicationController
+  def index
+    @infrastructure = Infrastructure.find(params[:infrastructure_id])
+    @infrastructure_variables = FindInfrastructureVariables.new(infrastructure: @infrastructure).call
+  end
+end

--- a/app/services/find_infrastructure_variables.rb
+++ b/app/services/find_infrastructure_variables.rb
@@ -1,0 +1,37 @@
+class FindInfrastructureVariables
+  include AwsClientWrapper
+
+  attr_writer :infrastructure
+
+  def initialize(infrastructure:)
+    self.infrastructure = infrastructure
+  end
+
+  def call
+    results = {}
+
+    infrastructure.environments.each do |environment_name, _blob|
+      results[environment_name] = fetch_environment_variables(
+        environment_name: environment_name
+      )
+    end
+
+    results
+  end
+
+  private
+
+  attr_reader :infrastructure
+
+  def fetch_environment_variables(environment_name:)
+    path = "/dalmatian-variables/infrastructures/#{infrastructure.identifier}/#{environment_name}/"
+
+    parameters = aws_ssm_client.get_parameters_by_path(
+      path: path,
+      with_decryption: true,
+      recursive: false
+    ).parameters
+
+    parameters.each { |p| p.name = File.basename(p.name) }
+  end
+end

--- a/app/services/get_aws_parameter.rb
+++ b/app/services/get_aws_parameter.rb
@@ -1,0 +1,20 @@
+class GetAwsParameter
+  include AwsClientWrapper
+
+  attr_accessor :infrastructure, :path
+
+  def initialize(infrastructure:, path:)
+    self.infrastructure = infrastructure
+    self.path = path
+  end
+
+  def call
+    parameters = aws_ssm_client.get_parameters_by_path(
+      path: path,
+      with_decryption: true,
+      recursive: false
+    ).parameters
+
+    parameters.each { |p| p.name = File.basename(p.name) }
+  end
+end

--- a/app/views/environment_variables/_environment_variable_table.html.erb
+++ b/app/views/environment_variables/_environment_variable_table.html.erb
@@ -13,7 +13,7 @@
     <% environment_variables.each do |variable| %>
       <tr>
         <td>
-          <%= form_tag(infrastructure_environment_variable_path(@infrastructure, id: variable.name), method: :delete) do %>
+          <%= form_tag(infrastructure_environment_variable_path(infrastructure, id: variable.name), method: :delete) do %>
             <%= hidden_field_tag 'environment_variable[name]', variable.name %>
             <%= hidden_field_tag 'environment_variable[service_name]', service_name %>
             <%= hidden_field_tag 'environment_variable[environment_name]', environment_name %>

--- a/app/views/environment_variables/index.html.erb
+++ b/app/views/environment_variables/index.html.erb
@@ -7,6 +7,6 @@
     <h3><%= "#{service_name}: #{environment_name}" %></h2>
     <%= link_to "Create or update variable", new_infrastructure_environment_variable_path(@infrastructure, service_name: service_name, environment_name: environment_name), class: "btn btn-primary" %>
 
-    <%= render 'environment_variable_table', environment_variables: environment_variables, service_name: service_name, environment_name: environment_name %>
+    <%= render 'environment_variable_table', infrastructure: @infrastructure, environment_variables: environment_variables, service_name: service_name, environment_name: environment_name %>
   <% end %>
 <% end %>

--- a/app/views/infrastructure_variables/_environment_variable_table.html.erb
+++ b/app/views/infrastructure_variables/_environment_variable_table.html.erb
@@ -1,0 +1,25 @@
+<table class="table table-dark table-striped table-bordered table-hover">
+  <thead>
+    <tr>
+      <th scope="col"></th>
+      <th scope="col">Name</th>
+      <th scope="col">Value</th>
+      <th scope="col">Last modified</th>
+      <th scope="col">Version</th>
+      <th scope="col">Data type</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% infrastructure_variables.each do |variable| %>
+      <tr>
+        <td>
+        </td>
+        <td><%= variable.name %></td>
+        <td><%= variable.value %></td>
+        <td><%= variable.last_modified_date %></td>
+        <td><%= variable.version %></td>
+        <td><%= variable.data_type %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/infrastructure_variables/index.html.erb
+++ b/app/views/infrastructure_variables/index.html.erb
@@ -1,0 +1,8 @@
+<h1 class="mt-5"><%= @infrastructure.identifier %></h1>
+
+<%= render "shared/tabs", locals: { infrastructure: @infrastructure } %>
+
+<% @infrastructure_variables.each_pair do |environment_name, infrastructure_variables| %>
+  <h3><%= "#{environment_name}" %></h2>
+  <%= render "environment_variable_table", infrastructure: @infrastructure, infrastructure_variables: infrastructure_variables, environment_name: environment_name %>
+<% end %>

--- a/app/views/shared/_tabs.html.erb
+++ b/app/views/shared/_tabs.html.erb
@@ -5,4 +5,7 @@
   <li class="nav-item">
     <%= link_to I18n.t("tab.environment_variables"), infrastructure_environment_variables_path(@infrastructure), class: "nav-link #{active_link(path: infrastructure_environment_variables_path(@infrastructure))}" %>
   </li>
+  <li class="nav-item">
+    <%= link_to I18n.t("tab.infrastructure_variables"), infrastructure_variables_path(@infrastructure), class: "nav-link #{active_link(path: infrastructure_variables_path(@infrastructure))}" %>
+  </li>
 </ul>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,3 +11,4 @@ en:
   tab:
     configuration: "Configuration"
     environment_variables: "Environment variables"
+    infrastructure_variables: "Infrastructure variables"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,6 @@ Rails.application.routes.draw do
 
   resources :infrastructures, only: [:show, :index] do
     resources :environment_variables, only: [:new, :create, :destroy, :index]
+    resources :infrastructure_variables, only: [:index], as: :variables
   end
 end

--- a/spec/features/users_can_see_infrastructure_variables_spec.rb
+++ b/spec/features/users_can_see_infrastructure_variables_spec.rb
@@ -1,0 +1,32 @@
+feature "Users can see infrastructure variables" do
+  scenario "lists out the keys and values" do
+    infrastructure = Infrastructure.create(
+      identifier: "test-app",
+      account_id: "345",
+      environments: {"staging" => []}
+    )
+
+    fake_environment_variable = create_aws_environment_variable(name: "FOO", value: "BAR")
+    fake_environment_variables = Aws::SSM::Types::GetParametersByPathResult.new(parameters: [
+      fake_environment_variable
+    ])
+
+    stub_call_to_aws_for_environment_variables(
+      account_id: infrastructure.account_id,
+      request_path: "/dalmatian-variables/infrastructures/test-app/staging/",
+      environment_variables: fake_environment_variables
+    )
+
+    visit infrastructure_path(infrastructure)
+
+    click_on(I18n.t("tab.infrastructure_variables"))
+
+    expect(page).to have_content("Infrastructure variables")
+    expect(page).to have_content("staging")
+    expect(page).to have_content("FOO")
+    expect(page).to have_content("BAR")
+    expect(page).to have_content(Time.new("2020-04-22 14:15:43 +0100").to_s)
+    expect(page).to have_content("19")
+    expect(page).to have_content("text")
+  end
+end

--- a/spec/services/find_infrastructure_variables_spec.rb
+++ b/spec/services/find_infrastructure_variables_spec.rb
@@ -1,0 +1,70 @@
+require "rails_helper"
+
+RSpec.describe FindInfrastructureVariables do
+  describe "#call" do
+    it "returns a hash of infrastructure variables grouped by environment" do
+      infrastructure = Infrastructure.new(
+        identifier: "test",
+        account_id: "345",
+        environments: {"staging" => []}
+      )
+
+      fake_environment_variable = create_aws_environment_variable(name: "FOO", value: "BAR")
+      fake_environment_variables = Aws::SSM::Types::GetParametersByPathResult.new(
+        parameters: [fake_environment_variable]
+      )
+
+      stub_call_to_aws_for_environment_variables(
+        account_id: infrastructure.account_id,
+        request_path: "/dalmatian-variables/infrastructures/test/staging/",
+        environment_variables: fake_environment_variables
+      )
+
+      result = described_class.new(infrastructure: infrastructure).call
+
+      expect(result).to eq({
+        "staging" => [fake_environment_variable]
+      })
+    end
+
+    context "when there are multiple environments" do
+      it "returns a hash of infrastructure variables grouped by environment" do
+        infrastructure = Infrastructure.new(
+          identifier: "test",
+          account_id: "345",
+          environments: {
+            "staging" => [],
+            "production" => []
+          }
+        )
+
+        fake_environment_variable = create_aws_environment_variable(name: "FOO", value: "BAR")
+        fake_environment_variables = Aws::SSM::Types::GetParametersByPathResult.new(
+          parameters: [fake_environment_variable]
+        )
+
+        aws_ssm_client = stub_aws_ssm_client(account_id: infrastructure.account_id)
+        stub_call_to_aws_for_environment_variables(
+          account_id: infrastructure.account_id,
+          aws_ssm_client_double: aws_ssm_client,
+          request_path: "/dalmatian-variables/infrastructures/test/staging/",
+          environment_variables: fake_environment_variables
+        )
+
+        stub_call_to_aws_for_environment_variables(
+          account_id: infrastructure.account_id,
+          aws_ssm_client_double: aws_ssm_client,
+          request_path: "/dalmatian-variables/infrastructures/test/production/",
+          environment_variables: fake_environment_variables
+        )
+
+        result = described_class.new(infrastructure: infrastructure).call
+
+        expect(result).to eq({
+          "staging" => [fake_environment_variable],
+          "production" => [fake_environment_variable]
+        })
+      end
+    end
+  end
+end

--- a/spec/services/get_aws_parameter_spec.rb
+++ b/spec/services/get_aws_parameter_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe GetAwsParameter do
+  describe "#call" do
+    it "returns a hash of infrastructure variables grouped by environment" do
+      infrastructure = Infrastructure.new(account_id: "345")
+      expected_request_path = "/foo/bar/baz"
+
+      fake_environment_variable = create_aws_environment_variable(name: "FOO", value: "BAR")
+      fake_environment_variables = Aws::SSM::Types::GetParametersByPathResult.new(
+        parameters: [fake_environment_variable]
+      )
+
+      stub_call_to_aws_for_environment_variables(
+        account_id: infrastructure.account_id,
+        request_path: expected_request_path,
+        environment_variables: fake_environment_variables
+      )
+
+      result = described_class.new(infrastructure: infrastructure, path: expected_request_path).call
+
+      expect(result).to eq([fake_environment_variable])
+    end
+  end
+end


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

Following the steer of the GUI prototype which used the path of "/dalmatian-variables/infrastructures/<infrastructure>/<environment>/". Using this path successfully retrieves existing values so that is why it's used.

Another difference between these and the other environment variables is that these are not concerned with the service. This diverges what's required at both service (class) and view level. Whilst there is some duplication of field names and class setup, separating these concerns should allow us to extend how we interact with each.

## Screenshots of UI changes

![Screenshot 2020-09-17 at 10 47 59](https://user-images.githubusercontent.com/912473/93454791-5c62fb00-f8d3-11ea-82e7-b20337136a33.png)

## Next steps
