### PR TITLE
Add and update infrastructure variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - environment variables are displayed on their own tab
 - infrastructure list is not longer full width
 - users can see infrastructure variables as well as environment variables for a given infrastructure
+- users can create and update infrastructure variables
 
 [unreleased]: TODO
 [keep a changelog 1.0.0]: https://keepachangelog.com/en/1.0.0/

--- a/app/controllers/environment_variables_controller.rb
+++ b/app/controllers/environment_variables_controller.rb
@@ -12,8 +12,10 @@ class EnvironmentVariablesController < ApplicationController
     @environment_variable = EnvironmentVariable.new(environment_variable_params)
 
     if @environment_variable.valid?
-      CreateEnvironmentVariable.new(infrastructure: @infrastructure)
-        .call(environment_variable: @environment_variable)
+      CreateEnvironmentVariable.new(
+        infrastructure: @infrastructure,
+        environment_variable: @environment_variable
+      ).call
       redirect_to infrastructure_environment_variables_path(@infrastructure)
     else
       render :new

--- a/app/controllers/infrastructure_variables_controller.rb
+++ b/app/controllers/infrastructure_variables_controller.rb
@@ -14,8 +14,7 @@ class InfrastructureVariablesController < ApplicationController
     if @infrastructure_variable.valid?
       CreateInfrastructureVariable.new(
         infrastructure: @infrastructure,
-        infrastructure_variable: @infrastructure_variable,
-        environment_name: environment_name
+        infrastructure_variable: @infrastructure_variable
       ).call
       redirect_to infrastructure_variables_path(@infrastructure)
     else
@@ -36,6 +35,6 @@ class InfrastructureVariablesController < ApplicationController
   private
 
   def infrastructure_variable_params
-    params.require("infrastructure_variable").permit(:name, :value)
+    params.require("infrastructure_variable").permit(:name, :value, :environment_name)
   end
 end

--- a/app/controllers/infrastructure_variables_controller.rb
+++ b/app/controllers/infrastructure_variables_controller.rb
@@ -1,8 +1,41 @@
 # frozen_string_literal: true
 
 class InfrastructureVariablesController < ApplicationController
+  def new
+    @infrastructure = Infrastructure.find(params[:infrastructure_id])
+    @infrastructure_variable = InfrastructureVariable.new
+  end
+
+  def create
+    @infrastructure = Infrastructure.find(params[:infrastructure_id])
+
+    @infrastructure_variable = InfrastructureVariable.new(infrastructure_variable_params)
+
+    if @infrastructure_variable.valid?
+      CreateInfrastructureVariable.new(
+        infrastructure: @infrastructure,
+        infrastructure_variable: @infrastructure_variable,
+        environment_name: environment_name
+      ).call
+      redirect_to infrastructure_variables_path(@infrastructure)
+    else
+      render :new
+    end
+  end
+
   def index
     @infrastructure = Infrastructure.find(params[:infrastructure_id])
     @infrastructure_variables = FindInfrastructureVariables.new(infrastructure: @infrastructure).call
+  end
+
+  def environment_name
+    params["environment_name"]
+  end
+  helper_method :environment_name
+
+  private
+
+  def infrastructure_variable_params
+    params.require("infrastructure_variable").permit(:name, :value)
   end
 end

--- a/app/models/infrastructure_variable.rb
+++ b/app/models/infrastructure_variable.rb
@@ -1,0 +1,5 @@
+class InfrastructureVariable
+  include ActiveModel::Model
+  
+  attr_accessor :name, :value
+end

--- a/app/models/infrastructure_variable.rb
+++ b/app/models/infrastructure_variable.rb
@@ -1,5 +1,8 @@
 class InfrastructureVariable
   include ActiveModel::Model
-  
-  attr_accessor :name, :value
+  include ActiveModel::Validations
+
+  attr_accessor :name, :value, :environment_name
+
+  validates :name, :value, :environment_name, presence: true
 end

--- a/app/services/create_environment_variable.rb
+++ b/app/services/create_environment_variable.rb
@@ -1,22 +1,25 @@
 class CreateEnvironmentVariable
   include AwsClientWrapper
 
-  attr_accessor :infrastructure
+  attr_accessor :infrastructure, :environment_variable
 
-  def initialize(infrastructure:)
+  def initialize(infrastructure:, environment_variable:)
     self.infrastructure = infrastructure
+    self.environment_variable = environment_variable
   end
 
-  def call(environment_variable:)
-    name_with_path = "/#{infrastructure.identifier}/#{environment_variable.full_aws_name}"
-    key_id = "alias/#{infrastructure.identifier}-#{environment_variable.service_name}-#{environment_variable.environment_name}-ssm"
+  def call
+    PutAwsParameter.new(infrastructure: infrastructure)
+      .call(path: name_with_path, key_id: key_id, value: environment_variable.value)
+  end
 
-    aws_ssm_client.put_parameter(
-      name: name_with_path,
-      value: environment_variable.value,
-      type: "SecureString",
-      key_id: key_id,
-      overwrite: true
-    )
+  private
+
+  def name_with_path
+    "/#{infrastructure.identifier}/#{environment_variable.full_aws_name}"
+  end
+
+  def key_id
+    "alias/#{infrastructure.identifier}-#{environment_variable.service_name}-#{environment_variable.environment_name}-ssm"
   end
 end

--- a/app/services/create_infrastructure_variable.rb
+++ b/app/services/create_infrastructure_variable.rb
@@ -1,12 +1,11 @@
 class CreateInfrastructureVariable
   include AwsClientWrapper
 
-  attr_accessor :infrastructure, :infrastructure_variable, :environment_name
+  attr_accessor :infrastructure, :infrastructure_variable
 
-  def initialize(infrastructure:, infrastructure_variable:, environment_name:)
+  def initialize(infrastructure:, infrastructure_variable:)
     self.infrastructure = infrastructure
     self.infrastructure_variable = infrastructure_variable
-    self.environment_name = environment_name
   end
 
   def call
@@ -17,7 +16,7 @@ class CreateInfrastructureVariable
   private
 
   def name_with_path
-    "/dalmatian-variables/infrastructures/#{infrastructure.identifier}/#{environment_name}/#{infrastructure_variable.name}"
+    "/dalmatian-variables/infrastructures/#{infrastructure.identifier}/#{infrastructure_variable.environment_name}/#{infrastructure_variable.name}"
   end
 
   def key_id

--- a/app/services/create_infrastructure_variable.rb
+++ b/app/services/create_infrastructure_variable.rb
@@ -1,0 +1,26 @@
+class CreateInfrastructureVariable
+  include AwsClientWrapper
+
+  attr_accessor :infrastructure, :infrastructure_variable, :environment_name
+
+  def initialize(infrastructure:, infrastructure_variable:, environment_name:)
+    self.infrastructure = infrastructure
+    self.infrastructure_variable = infrastructure_variable
+    self.environment_name = environment_name
+  end
+
+  def call
+    PutAwsParameter.new(infrastructure: infrastructure)
+      .call(path: name_with_path, key_id: key_id, value: infrastructure_variable.value)
+  end
+
+  private
+
+  def name_with_path
+    "/dalmatian-variables/infrastructures/#{infrastructure.identifier}/#{environment_name}/#{infrastructure_variable.name}"
+  end
+
+  def key_id
+    "alias/dalmatian"
+  end
+end

--- a/app/services/put_aws_parameter.rb
+++ b/app/services/put_aws_parameter.rb
@@ -1,0 +1,19 @@
+class PutAwsParameter
+  include AwsClientWrapper
+
+  attr_accessor :infrastructure
+
+  def initialize(infrastructure:)
+    self.infrastructure = infrastructure
+  end
+
+  def call(path:, key_id:, value:)
+    aws_ssm_client.put_parameter(
+      name: path,
+      value: value,
+      type: "SecureString",
+      key_id: key_id,
+      overwrite: true
+    )
+  end
+end

--- a/app/views/environment_variables/index.html.erb
+++ b/app/views/environment_variables/index.html.erb
@@ -5,7 +5,7 @@
 <% @environment_variables.keys.each do |service_name| %>
   <% @environment_variables[service_name].each_pair do |environment_name, environment_variables| %>
     <h3><%= "#{service_name}: #{environment_name}" %></h2>
-    <%= link_to "Create or update variable", new_infrastructure_environment_variable_path(@infrastructure, service_name: service_name, environment_name: environment_name), class: "btn btn-primary" %>
+    <%= link_to I18n.t("button.add_or_update_variable"), new_infrastructure_environment_variable_path(@infrastructure, service_name: service_name, environment_name: environment_name), class: "btn btn-primary" %>
 
     <%= render 'environment_variable_table', infrastructure: @infrastructure, environment_variables: environment_variables, service_name: service_name, environment_name: environment_name %>
   <% end %>

--- a/app/views/environment_variables/new.html.erb
+++ b/app/views/environment_variables/new.html.erb
@@ -1,5 +1,5 @@
 <div class="col-4 offset-4">
-  <h1 class="mt-5">Create or update variable</h1>
+  <h1 class="mt-5"><%= I18n.t("page_title.environment_variable.new") %></h1>
 
   <p>If you provide an existing variable name this will update the existing value. It is case sensitive.</p>
   <%= simple_form_for(@environment_variable, as: :environment_variable, method: :post, url: infrastructure_environment_variables_path(@infrastructure, service_name: service_name, environment_name: environment_name)) do |f| %>
@@ -7,6 +7,6 @@
     <%= f.input :environment_name, as: :hidden, :input_html => { :value => environment_name } %>
     <%= f.input :name %>
     <%= f.input :value %>
-    <%= f.submit "Create or update variable", class: "btn btn-success" %>
+    <%= f.submit I18n.t("button.add_or_update_variable"), class: "btn btn-success" %>
   <% end %>
 </div>

--- a/app/views/infrastructure_variables/index.html.erb
+++ b/app/views/infrastructure_variables/index.html.erb
@@ -4,5 +4,7 @@
 
 <% @infrastructure_variables.each_pair do |environment_name, infrastructure_variables| %>
   <h3><%= "#{environment_name}" %></h2>
+  <%= link_to I18n.t("button.add_or_update_variable"), new_infrastructure_variable_path(@infrastructure, environment_name: environment_name), class: "btn btn-primary" %>
+
   <%= render "environment_variable_table", infrastructure: @infrastructure, infrastructure_variables: infrastructure_variables, environment_name: environment_name %>
 <% end %>

--- a/app/views/infrastructure_variables/new.html.erb
+++ b/app/views/infrastructure_variables/new.html.erb
@@ -1,0 +1,13 @@
+<div class="col-4 offset-4">
+  <h1 class="mt-5">
+    <%= I18n.t("page_title.infrastructure_variable.new") %>
+  </h1>
+
+  <p>If you provide an existing variable name this will update the existing value. It is case sensitive.</p>
+  <%= simple_form_for(@infrastructure_variable, as: :infrastructure_variable, method: :post, url: infrastructure_variables_path(@infrastructure, environment_name: environment_name)) do |f| %>
+    <%= f.input :environment_name, as: :hidden, :input_html => { :value => environment_name } %>
+    <%= f.input :name %>
+    <%= f.input :value %>
+    <%= f.submit I18n.t("button.add_or_update_variable"), class: "btn btn-success" %>
+  <% end %>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,6 +5,8 @@ en:
     infrastructures: "Infrastructures"
     environment_variable:
       new: "Create or update variable"
+    infrastructure_variable:
+      new: "Create or update variable"
   button:
     add_or_update_variable: "Create or update variable"
     delete: "Delete"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,9 +4,9 @@ en:
   page_title:
     infrastructures: "Infrastructures"
     environment_variable:
-      new: "Create or update variable"
+      new: "Create or update environment variable"
     infrastructure_variable:
-      new: "Create or update variable"
+      new: "Create or update infrastructure variable"
   button:
     add_or_update_variable: "Create or update variable"
     delete: "Delete"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,6 @@ Rails.application.routes.draw do
 
   resources :infrastructures, only: [:show, :index] do
     resources :environment_variables, only: [:new, :create, :destroy, :index]
-    resources :infrastructure_variables, only: [:index], as: :variables
+    resources :infrastructure_variables, only: [:new, :create, :index], as: :variables
   end
 end

--- a/spec/features/users_can_add_a_new_infrastructure_variable_spec.rb
+++ b/spec/features/users_can_add_a_new_infrastructure_variable_spec.rb
@@ -116,4 +116,24 @@ feature "Users can add new infrastructure variables" do
     expect(page).to have_content("NEW_VALUE")
     expect(page).to_not have_content("EXISTING_VARIABLE_VALUE")
   end
+
+  scenario "validates the presence of both values" do
+    infrastructure = Infrastructure.create(
+      identifier: "test-app",
+      account_id: "345",
+      services: [{"name" => "test-service"}],
+      environments: {"staging" => []}
+    )
+
+    # Deliberately omit query params for service_name and environment_name
+    visit new_infrastructure_variable_path(infrastructure)
+
+    fill_in "infrastructure_variable[name]", with: "" # Deliberately omit a value
+    fill_in "infrastructure_variable[value]", with: "" # Deliberately omit a value
+    click_on I18n.t("button.add_or_update_variable")
+
+    expect(page).to have_content("Environment name can't be blank")
+    expect(page).to have_content("Name can't be blank")
+    expect(page).to have_content("Value can't be blank")
+  end
 end

--- a/spec/features/users_can_add_a_new_infrastructure_variable_spec.rb
+++ b/spec/features/users_can_add_a_new_infrastructure_variable_spec.rb
@@ -1,0 +1,119 @@
+feature "Users can add new infrastructure variables" do
+  scenario "adds a new variable" do
+    infrastructure = Infrastructure.create(
+      identifier: "test-app",
+      account_id: "345",
+      services: [{"name" => "test-service"}],
+      environments: {"staging" => []}
+    )
+
+    aws_ssm_client = stub_aws_ssm_client(account_id: infrastructure.account_id)
+
+    stub_call_to_aws_for_environment_variables(
+      aws_ssm_client_double: aws_ssm_client,
+      account_id: infrastructure.account_id,
+      request_path: "/dalmatian-variables/infrastructures/test-app/staging/",
+      environment_variables: Aws::SSM::Types::GetParametersByPathResult.new(parameters: [])
+    )
+
+    visit infrastructure_path(infrastructure)
+    click_on(I18n.t("tab.infrastructure_variables"))
+    click_on(I18n.t("button.add_or_update_variable"))
+
+    within("h1") do
+      expect(page).to have_content(I18n.t("page_title.infrastructure_variable.new"))
+    end
+
+    stub_call_to_aws_to_update_infrastructure_variables(
+      aws_ssm_client_double: aws_ssm_client,
+      account_id: infrastructure.account_id,
+      infrastructure_identifier: infrastructure.identifier,
+      environment_name: "staging",
+      variable_name: "FOO",
+      variable_value: "BAAZ"
+    )
+
+    updated_environment_variable = create_aws_environment_variable(name: "FOO", value: "BAAZ")
+    updated_environment_variables = Aws::SSM::Types::GetParametersByPathResult.new(
+      parameters: [updated_environment_variable]
+    )
+
+    stub_call_to_aws_for_environment_variables(
+      aws_ssm_client_double: aws_ssm_client,
+      account_id: infrastructure.account_id,
+      request_path: "/dalmatian-variables/infrastructures/test-app/staging/",
+      environment_variables: updated_environment_variables
+    )
+
+    fill_in "infrastructure_variable[name]", with: "FOO"
+    fill_in "infrastructure_variable[value]", with: "BAAZ"
+    click_on I18n.t("button.add_or_update_variable")
+
+    expect(page).to have_content("FOO")
+    expect(page).to have_content("BAAZ")
+  end
+
+  scenario "updates an existing variable" do
+    infrastructure = Infrastructure.create(
+      identifier: "test-app",
+      account_id: "345",
+      services: [{"name" => "test-service"}],
+      environments: {"staging" => []}
+    )
+
+    aws_ssm_client = stub_aws_ssm_client(account_id: infrastructure.account_id)
+
+    existing_environment_variable = create_aws_environment_variable(name: "EXISTING_VARIABLE_NAME", value: "EXISTING_VARIABLE_VALUE")
+    existing_environment_variables = Aws::SSM::Types::GetParametersByPathResult.new(
+      parameters: [existing_environment_variable]
+    )
+
+    stub_call_to_aws_for_environment_variables(
+      aws_ssm_client_double: aws_ssm_client,
+      account_id: infrastructure.account_id,
+      request_path: "/dalmatian-variables/infrastructures/test-app/staging/",
+      environment_variables: existing_environment_variables
+    )
+
+    visit infrastructure_path(infrastructure)
+    click_on(I18n.t("tab.infrastructure_variables"))
+
+    expect(page).to have_content("EXISTING_VARIABLE_NAME")
+    expect(page).to have_content("EXISTING_VARIABLE_VALUE")
+
+    click_on(I18n.t("button.add_or_update_variable"))
+
+    within("h1") do
+      expect(page).to have_content(I18n.t("page_title.infrastructure_variable.new"))
+    end
+
+    stub_call_to_aws_to_update_infrastructure_variables(
+      aws_ssm_client_double: aws_ssm_client,
+      account_id: infrastructure.account_id,
+      infrastructure_identifier: infrastructure.identifier,
+      environment_name: "staging",
+      variable_name: "EXISTING_VARIABLE_NAME",
+      variable_value: "NEW_VALUE"
+    )
+
+    updated_environment_variable = create_aws_environment_variable(name: "EXISTING_VARIABLE_NAME", value: "NEW_VALUE")
+    updated_environment_variables = Aws::SSM::Types::GetParametersByPathResult.new(
+      parameters: [updated_environment_variable]
+    )
+
+    stub_call_to_aws_for_environment_variables(
+      aws_ssm_client_double: aws_ssm_client,
+      account_id: infrastructure.account_id,
+      request_path: "/dalmatian-variables/infrastructures/test-app/staging/",
+      environment_variables: updated_environment_variables
+    )
+
+    fill_in "infrastructure_variable[name]", with: "EXISTING_VARIABLE_NAME"
+    fill_in "infrastructure_variable[value]", with: "NEW_VALUE"
+    click_on I18n.t("button.add_or_update_variable")
+
+    expect(page).to have_content("EXISTING_VARIABLE_NAME")
+    expect(page).to have_content("NEW_VALUE")
+    expect(page).to_not have_content("EXISTING_VARIABLE_VALUE")
+  end
+end

--- a/spec/services/put_aws_parameter_spec.rb
+++ b/spec/services/put_aws_parameter_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe PutAwsParameter do
+  describe "#call" do
+    it "asks AWS to update the variable" do
+      infrastructure = Infrastructure.new(account_id: "345")
+      expected_request_path = "/foo/bar/baz/FOO"
+      expected_key_id = "alias/foo-bar-baz-ssm"
+
+      stub_call_to_aws_to_update_environment_variables(
+        account_id: infrastructure.account_id,
+        infrastructure_identifier: "foo",
+        service_name: "bar",
+        environment_name: "baz",
+        variable_name: "FOO",
+        variable_value: "BAR"
+      )
+
+      result = described_class.new(
+        infrastructure: infrastructure
+      ).call(
+        path: expected_request_path,
+        key_id: expected_key_id,
+        value: "BAR"
+      )
+
+      expect(result).to be_kind_of(Aws::SSM::Types::PutParameterResult)
+    end
+  end
+end

--- a/spec/support/aws_api_helpers.rb
+++ b/spec/support/aws_api_helpers.rb
@@ -58,6 +58,33 @@ module AwsApiHelpers
       ).and_return(fake_result)
   end
 
+  def stub_call_to_aws_to_update_infrastructure_variables(
+    aws_ssm_client_double: nil,
+    account_id:,
+    infrastructure_identifier:,
+    environment_name:,
+    variable_name:,
+    variable_value:
+  )
+    aws_ssm_client = aws_ssm_client_double || stub_aws_ssm_client(account_id: account_id)
+
+    path = "/dalmatian-variables/infrastructures/#{infrastructure_identifier}/#{environment_name}/"
+    name_with_path = "#{path}#{variable_name}"
+    key_id = "alias/dalmatian"
+
+    fake_result = Aws::SSM::Types::PutParameterResult.new(version: 2, tier: "Standard")
+
+    allow(aws_ssm_client)
+      .to receive(:put_parameter)
+      .with(
+        name: name_with_path,
+        value: variable_value,
+        type: "SecureString",
+        key_id: key_id,
+        overwrite: true
+      ).and_return(fake_result)
+  end
+
   def stub_call_to_aws_to_delete_environment_variable(
     aws_ssm_client_double: nil,
     account_id:,


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

- refactor the way _environment_ variables were created for easier reuse as the AWS API call is the same. Create and reuse a new service called `PutAwsParameter` for both actions
- users can add new infrastructure variables per environment
- users can update existing infrastructure variables

## Screenshots of UI changes

![Screenshot 2020-09-21 at 14 32 46](https://user-images.githubusercontent.com/912473/93773323-e8e52480-fc17-11ea-8cbe-99d527f2c368.png)
![Screenshot 2020-09-21 at 14 35 53](https://user-images.githubusercontent.com/912473/93773340-ec78ab80-fc17-11ea-9655-7081e2e4ce42.png)
