### PR TITLE
Users can delete infrastructure variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - infrastructure list is not longer full width
 - users can see infrastructure variables as well as environment variables for a given infrastructure
 - users can create and update infrastructure variables
+- users can delete infrastructure variables
 
 [unreleased]: TODO
 [keep a changelog 1.0.0]: https://keepachangelog.com/en/1.0.0/

--- a/app/controllers/infrastructure_variables_controller.rb
+++ b/app/controllers/infrastructure_variables_controller.rb
@@ -22,6 +22,16 @@ class InfrastructureVariablesController < ApplicationController
     end
   end
 
+  def destroy
+    @infrastructure = Infrastructure.find(params[:infrastructure_id])
+
+    infrastructure_variable = InfrastructureVariable.new(infrastructure_variable_params)
+    result = DeleteInfrastructureVariable.new(infrastructure: @infrastructure).call(infrastructure_variable: infrastructure_variable)
+
+    flash_message = result.success? ? {notice: "#{infrastructure_variable.name} has been successfully deleted"} : {error: result.error_message}
+    redirect_to infrastructure_variables_path(@infrastructure), flash: flash_message
+  end
+
   def index
     @infrastructure = Infrastructure.find(params[:infrastructure_id])
     @infrastructure_variables = FindInfrastructureVariables.new(infrastructure: @infrastructure).call

--- a/app/services/delete_aws_parameter.rb
+++ b/app/services/delete_aws_parameter.rb
@@ -1,0 +1,16 @@
+class DeleteAwsParameter
+  include AwsClientWrapper
+
+  attr_accessor :infrastructure
+
+  def initialize(infrastructure:)
+    self.infrastructure = infrastructure
+  end
+
+  def call(path:)
+    aws_ssm_client.delete_parameter(name: path)
+    Result.new(true)
+  rescue Aws::SSM::Errors::ParameterNotFound => error
+    Result.new(false, error, "Parameter was not found")
+  end
+end

--- a/app/services/delete_environment_variable.rb
+++ b/app/services/delete_environment_variable.rb
@@ -1,6 +1,4 @@
 class DeleteEnvironmentVariable
-  include AwsClientWrapper
-
   attr_accessor :infrastructure
 
   def initialize(infrastructure:)
@@ -10,11 +8,7 @@ class DeleteEnvironmentVariable
   def call(environment_variable:)
     full_name = "#{infrastructure.identifier}/#{environment_variable.full_aws_name}"
 
-    begin
-      aws_ssm_client.delete_parameter(name: full_name)
-      Result.new(true)
-    rescue Aws::SSM::Errors::ParameterNotFound => error
-      Result.new(false, error, "Parameter was not found")
-    end
+    result = DeleteAwsParameter.new(infrastructure: infrastructure).call(path: full_name)
+    result
   end
 end

--- a/app/services/delete_infrastructure_variable.rb
+++ b/app/services/delete_infrastructure_variable.rb
@@ -1,0 +1,14 @@
+class DeleteInfrastructureVariable
+  attr_accessor :infrastructure
+
+  def initialize(infrastructure:)
+    self.infrastructure = infrastructure
+  end
+
+  def call(infrastructure_variable:)
+    full_name = "/dalmatian-variables/infrastructures/#{infrastructure.identifier}/#{infrastructure_variable.environment_name}/#{infrastructure_variable.name}"
+
+    result = DeleteAwsParameter.new(infrastructure: infrastructure).call(path: full_name)
+    result
+  end
+end

--- a/app/views/infrastructure_variables/_environment_variable_table.html.erb
+++ b/app/views/infrastructure_variables/_environment_variable_table.html.erb
@@ -13,6 +13,11 @@
     <% infrastructure_variables.each do |variable| %>
       <tr>
         <td>
+          <%= form_tag(infrastructure_variable_path(infrastructure, id: variable.name), method: :delete) do %>
+            <%= hidden_field_tag 'infrastructure_variable[name]', variable.name %>
+            <%= hidden_field_tag 'infrastructure_variable[environment_name]', environment_name %>
+            <%= submit_tag "Delete", class: "btn btn-danger", "data-confirm" => "Are you sure you want to remove '#{variable.name}' for the '#{environment_name}' environment?" %>
+          <% end %>
         </td>
         <td><%= variable.name %></td>
         <td><%= variable.value %></td>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,6 @@ Rails.application.routes.draw do
 
   resources :infrastructures, only: [:show, :index] do
     resources :environment_variables, only: [:new, :create, :destroy, :index]
-    resources :infrastructure_variables, only: [:new, :create, :index], as: :variables
+    resources :infrastructure_variables, only: [:new, :create, :destroy, :index], as: :variables
   end
 end

--- a/spec/features/users_can_delete_an_infrastructure_variable_spec.rb
+++ b/spec/features/users_can_delete_an_infrastructure_variable_spec.rb
@@ -1,8 +1,8 @@
-feature "Users can delete environment variables" do
+feature "Users can delete infrastructure variables" do
   let(:infrastructure) do
     Infrastructure.create(
       identifier: "test-app",
-      account_id: "345",
+      account_id: "9923123",
       services: [{"name" => "test-service"}],
       environments: {"staging" => []}
     )
@@ -18,23 +18,23 @@ feature "Users can delete environment variables" do
     stub_call_to_aws_for_environment_variables(
       aws_ssm_client_double: aws_ssm_client,
       account_id: infrastructure.account_id,
-      request_path: "/test-app/test-service/staging/",
+      request_path: "/dalmatian-variables/infrastructures/test-app/staging/",
       environment_variables: existing_environment_variables
     )
 
     stub_call_to_aws_to_delete_environment_variable(
       aws_ssm_client_double: aws_ssm_client,
       account_id: infrastructure.account_id,
-      request_path: "test-app/test-service/staging",
+      request_path: "/dalmatian-variables/infrastructures/test-app/staging",
       name: "EXISTING_VARIABLE_NAME"
     )
 
-    visit infrastructure_environment_variables_path(infrastructure)
+    visit infrastructure_variables_path(infrastructure)
 
     stub_call_to_aws_for_environment_variables(
       aws_ssm_client_double: aws_ssm_client,
       account_id: infrastructure.account_id,
-      request_path: "/test-app/test-service/staging/",
+      request_path: "/dalmatian-variables/infrastructures/test-app/staging/",
       environment_variables: Aws::SSM::Types::GetParametersByPathResult.new(parameters: [])
     )
 

--- a/spec/services/delete_aws_parameter_spec.rb
+++ b/spec/services/delete_aws_parameter_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe DeleteAwsParameter do
+  describe "#call" do
+    it "returns an object with the new parameter version number" do
+      infrastructure = Infrastructure.new(account_id: "345")
+
+      stub_call_to_aws_to_delete_environment_variable(
+        account_id: infrastructure.account_id,
+        request_path: "/dalmatian-variables/infrastructures/test-app/staging",
+        name: "EXISTING_VARIABLE_NAME"
+      )
+
+      expected_request_path = "/dalmatian-variables/infrastructures/test-app/staging/EXISTING_VARIABLE_NAME"
+
+      result = described_class.new(infrastructure: infrastructure)
+        .call(path: expected_request_path)
+
+      expect(result).to be_kind_of(Result)
+      expect(result.success?).to eq(true)
+    end
+  end
+end


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

- refactor the way we delete _environment_ variables to reuse it for deleting _infrastructure_ variables
- users can delete environment variables for each environment

## Screenshots of UI changes

![Screenshot 2020-09-21 at 15 54 07](https://user-images.githubusercontent.com/912473/93782834-ed630a80-fc22-11ea-966e-fcb07224b308.png)
![Screenshot 2020-09-21 at 15 54 15](https://user-images.githubusercontent.com/912473/93782840-ef2cce00-fc22-11ea-96b2-a6b87a243745.png)
