### PR TITLE
Add margins to page headers and remove table scrolling

### DIFF
--- a/app/views/environment_variables/_environment_variable_table.html.erb
+++ b/app/views/environment_variables/_environment_variable_table.html.erb
@@ -1,4 +1,4 @@
-<table class="table table-dark table-striped table-bordered table-hover">
+<table class="table table-dark table-striped table-bordered table-hover table-responsive">
   <thead>
     <tr>
       <th scope="col"></th>
@@ -20,8 +20,8 @@
             <%= submit_tag "Delete", class: "btn btn-danger", "data-confirm" => "Are you sure you want to remove '#{variable.name}' for '#{service_name}' in the '#{environment_name}' environment?" %>
           <% end %>
         </td>
-        <td><%= variable.name %></td>
-        <td><%= variable.value %></td>
+        <td class="text-break"><%= variable.name %></td>
+        <td class="text-break"><%= variable.value %></p></td>
         <td><%= variable.last_modified_date %></td>
         <td><%= variable.version %></td>
         <td><%= variable.data_type %></td>

--- a/app/views/environment_variables/index.html.erb
+++ b/app/views/environment_variables/index.html.erb
@@ -1,12 +1,18 @@
-<h1 class="mt-5"><%= @infrastructure.identifier %></h1>
+<h1 class="mt-4 mb-4"><%= @infrastructure.identifier %></h1>
 
 <%= render "shared/tabs", locals: { infrastructure: @infrastructure } %>
 
-<% @environment_variables.keys.each do |service_name| %>
-  <% @environment_variables[service_name].each_pair do |environment_name, environment_variables| %>
-    <h3><%= "#{service_name}: #{environment_name}" %></h2>
-    <%= link_to I18n.t("button.add_or_update_variable"), new_infrastructure_environment_variable_path(@infrastructure, service_name: service_name, environment_name: environment_name), class: "btn btn-primary" %>
+<div class="col-12 col-md-12 pt-4">
+  <% @environment_variables.keys.each do |service_name| %>
+    <% @environment_variables[service_name].each_pair do |environment_name, environment_variables| %>
 
-    <%= render 'environment_variable_table', infrastructure: @infrastructure, environment_variables: environment_variables, service_name: service_name, environment_name: environment_name %>
+      <h3>
+        <%= service_name %>
+        <small class="text-muted"><%= environment_name %> environment</small>
+      </h3>
+      <%= link_to I18n.t("button.add_or_update_variable"), new_infrastructure_environment_variable_path(@infrastructure, service_name: service_name, environment_name: environment_name), class: "btn btn-primary mb-4" %>
+
+      <%= render 'environment_variable_table', infrastructure: @infrastructure, environment_variables: environment_variables, service_name: service_name, environment_name: environment_name %>
+    <% end %>
   <% end %>
-<% end %>
+</div>

--- a/app/views/infrastructure_variables/_environment_variable_table.html.erb
+++ b/app/views/infrastructure_variables/_environment_variable_table.html.erb
@@ -1,4 +1,4 @@
-<table class="table table-dark table-striped table-bordered table-hover">
+<table class="table table-dark table-striped table-bordered table-hover table-responsive">
   <thead>
     <tr>
       <th scope="col"></th>
@@ -19,8 +19,8 @@
             <%= submit_tag "Delete", class: "btn btn-danger", "data-confirm" => "Are you sure you want to remove '#{variable.name}' for the '#{environment_name}' environment?" %>
           <% end %>
         </td>
-        <td><%= variable.name %></td>
-        <td><%= variable.value %></td>
+        <td class="text-break"><%= variable.name %></td>
+        <td class="text-break"><%= variable.value %></td>
         <td><%= variable.last_modified_date %></td>
         <td><%= variable.version %></td>
         <td><%= variable.data_type %></td>

--- a/app/views/infrastructure_variables/index.html.erb
+++ b/app/views/infrastructure_variables/index.html.erb
@@ -1,10 +1,15 @@
-<h1 class="mt-5"><%= @infrastructure.identifier %></h1>
+<h1 class="mt-4 mb-4"><%= @infrastructure.identifier %></h1>
 
 <%= render "shared/tabs", locals: { infrastructure: @infrastructure } %>
 
-<% @infrastructure_variables.each_pair do |environment_name, infrastructure_variables| %>
-  <h3><%= "#{environment_name}" %></h2>
-  <%= link_to I18n.t("button.add_or_update_variable"), new_infrastructure_variable_path(@infrastructure, environment_name: environment_name), class: "btn btn-primary" %>
+<div class="col-12 col-md-12 mt-4">
+  <% @infrastructure_variables.each_pair do |environment_name, infrastructure_variables| %>
+    <h3>
+      <%= environment_name %>
+      <small class="text-muted">environment</small>
+    </h3>
+    <%= link_to I18n.t("button.add_or_update_variable"), new_infrastructure_variable_path(@infrastructure, environment_name: environment_name), class: "btn btn-primary mb-4" %>
 
-  <%= render "environment_variable_table", infrastructure: @infrastructure, infrastructure_variables: infrastructure_variables, environment_name: environment_name %>
-<% end %>
+    <%= render "environment_variable_table", infrastructure: @infrastructure, infrastructure_variables: infrastructure_variables, environment_name: environment_name %>
+  <% end %>
+</div>

--- a/app/views/infrastructures/index.html.erb
+++ b/app/views/infrastructures/index.html.erb
@@ -1,7 +1,5 @@
 <div class="col-6 offset-3">
-  <h1 class="mt-5">
-    <%= I18n.t("page_title.infrastructures") %>
-  </h1>
+  <h1 class="mt-4 mb-4"><%= I18n.t("page_title.infrastructures") %></h1>
 
   <ul class="list-group">
     <% @infrastructures.each do |infrastructure| %>

--- a/app/views/infrastructures/show.html.erb
+++ b/app/views/infrastructures/show.html.erb
@@ -1,10 +1,12 @@
-<h1 class="mt-5"><%= @infrastructure.identifier %></h1>
+<h1 class="mt-4 mb-4"><%= @infrastructure.identifier %></h1>
 
 <%= render "shared/tabs", locals: { infrastructure: @infrastructure } %>
 
-<h2 class="mt-5">Dalmatian config</h2>
-<pre>
-  <code>
-    <%= JSON.pretty_generate(@infrastructure.attributes) %>
-  </code>
-</pre>
+<div class="col-12 col-md-12 mt-4">
+  <h2 class="mt-4">Dalmatian config</h2>
+  <pre>
+    <code>
+      <%= JSON.pretty_generate(@infrastructure.attributes) %>
+    </code>
+  </pre>
+</div>


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

- add consistent margin to page headers to add some clearance between page elements
- values for environment variable names and values (which have no max length) are text wrapped if the screen size is reduced rather than scrolling horizontally
- add in contextual "environment" for the infrastructure variable index page

## Screenshots of UI changes

### Before

![Screenshot 2020-09-21 at 15 53 39](https://user-images.githubusercontent.com/912473/93786725-8dbb2e00-fc27-11ea-946a-484d5a61abc3.png)

### After

![Screenshot 2020-09-21 at 16 27 24](https://user-images.githubusercontent.com/912473/93786703-885de380-fc27-11ea-9c40-8d673a2f3ecd.png)

## Next steps
