### PR TITLE
Feature/users can show and hide env secrets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,5 @@ DATABASE_URL=mongodb://127.0.0.1:27017/dalmatian-frontend-development
 
 # AWS
 AWS_ROLE=
+
+HIDE_SECRETS_BY_DEFAULT=true

--- a/.env.test
+++ b/.env.test
@@ -9,3 +9,5 @@ DATABASE_URL=mongodb://127.0.0.1:27017/dalmatian-frontend-test
 
 # AWS
 AWS_ROLE=test
+
+HIDE_SECRETS_BY_DEFAULT=false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The format is based on [Keep a Changelog 1.0.0].
 - users can create and update infrastructure variables
 - users can delete infrastructure variables
 - users are shown a warning about the effect of using any action within the service
+- secret environment variables are hidden by default
+- secret environment variables can be shown and hidden individually by clicking the cell
 
 [unreleased]: TODO
 [keep a changelog 1.0.0]: https://keepachangelog.com/en/1.0.0/

--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ end
 
 group :test do
   gem "capybara", ">= 2.15"
+  gem "climate_control"
   gem "database_cleaner"
   gem "launchy"
   gem "geckodriver-helper"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,7 @@ GEM
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
     childprocess (3.0.0)
+    climate_control (0.2.0)
     coderay (1.1.3)
     coffee-rails (5.0.0)
       coffee-script (>= 2.2.0)
@@ -346,6 +347,7 @@ DEPENDENCIES
   bullet
   byebug
   capybara (>= 2.15)
+  climate_control
   coffee-rails (~> 5.0)
   database_cleaner
   dotenv-rails

--- a/app/assets/javascripts/obfuscate.js.coffee
+++ b/app/assets/javascripts/obfuscate.js.coffee
@@ -1,0 +1,12 @@
+$(document).ready ->
+  $('.secret-cell').on 'click', (e) ->
+    secret = $(@).attr('data-secret')
+    obfuscation = '************************************'
+    current_value = $(@).html().replace(/\s/g, '')
+
+    if current_value == obfuscation
+      $(@).html secret
+    else
+      $(@).html obfuscation
+
+    return

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,7 +7,7 @@ module ApplicationHelper
 
   def present_sensitive_value(value)
     if ENV["HIDE_SECRETS_BY_DEFAULT"] == "true"
-      "************************************"
+      I18n.t("obfuscation")
     else
       value
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,4 +4,12 @@ module ApplicationHelper
   def active_link(path:)
     return "active" if path == request.path
   end
+
+  def present_sensitive_value(value)
+    if ENV["HIDE_SECRETS_BY_DEFAULT"] == "true"
+      "************************************"
+    else
+      value
+    end
+  end
 end

--- a/app/views/environment_variables/_environment_variable_table.html.erb
+++ b/app/views/environment_variables/_environment_variable_table.html.erb
@@ -21,7 +21,9 @@
           <% end %>
         </td>
         <td class="text-break"><%= variable.name %></td>
-        <td class="text-break"><%= variable.value %></p></td>
+        <td class="secret-cell text-break" data-secret=<%= "#{variable.value}"%>>
+          <%= present_sensitive_value(variable.value) %>
+        </td>
         <td><%= variable.last_modified_date %></td>
         <td><%= variable.version %></td>
         <td><%= variable.data_type %></td>

--- a/app/views/infrastructure_variables/_environment_variable_table.html.erb
+++ b/app/views/infrastructure_variables/_environment_variable_table.html.erb
@@ -20,7 +20,9 @@
           <% end %>
         </td>
         <td class="text-break"><%= variable.name %></td>
-        <td class="text-break"><%= variable.value %></td>
+        <td class="secret-cell text-break" data-secret=<%= "#{variable.value}"%>>
+          <%= present_sensitive_value(variable.value) %>
+        </td>
         <td><%= variable.last_modified_date %></td>
         <td><%= variable.version %></td>
         <td><%= variable.data_type %></td>

--- a/config/initializers/dotenv.rb
+++ b/config/initializers/dotenv.rb
@@ -1,4 +1,4 @@
 # Require environment variables on initialisation
 # https://github.com/bkeepers/dotenv#required-keys
 Dotenv.require_keys if defined?(Dotenv)
-Dotenv.require_keys("AWS_ROLE")
+Dotenv.require_keys("AWS_ROLE", "HIDE_SECRETS_BY_DEFAULT")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -18,3 +18,4 @@ en:
     introduction_warning:
       short: "Use with caution."
       long: "This tool authenticates with your machines real AWS credentials. Despite being run locally, any action performed here will make real requests to AWS which may affect live services."
+  obfuscation: "************************************"

--- a/spec/features/users_show_and_hide_secret_variables_spec.rb
+++ b/spec/features/users_show_and_hide_secret_variables_spec.rb
@@ -1,0 +1,86 @@
+feature "Users can show and hide secret variables" do
+  let(:infrastructure) do
+    Infrastructure.create(
+      identifier: "test-app",
+      account_id: "345",
+      services: [{"name" => "test-service"}],
+      environments: {"staging" => []}
+    )
+  end
+
+  context "when the app is configured to HIDE secrets by default" do
+    around do |example|
+      ClimateControl.modify HIDE_SECRETS_BY_DEFAULT: "true" do
+        example.run
+      end
+    end
+
+    scenario "values are hidden by default" do
+      environment_variable = create_aws_environment_variable(name: "FOO", value: "BAAZ")
+      environment_variables = Aws::SSM::Types::GetParametersByPathResult.new(
+        parameters: [environment_variable]
+      )
+
+      stub_call_to_aws_for_environment_variables(
+        account_id: infrastructure.account_id,
+        request_path: "/test-app/test-service/staging/",
+        environment_variables: environment_variables
+      )
+
+      visit infrastructure_environment_variables_path(infrastructure)
+
+      expect(page).to have_content(I18n.t("obfuscation"))
+      expect(page).not_to have_content("BAAZ")
+    end
+
+    scenario "values can be shown by clicking", js: true do
+      environment_variable = create_aws_environment_variable(name: "FOO", value: "BAAZ")
+      environment_variables = Aws::SSM::Types::GetParametersByPathResult.new(
+        parameters: [environment_variable]
+      )
+
+      stub_call_to_aws_for_environment_variables(
+        account_id: infrastructure.account_id,
+        request_path: "/test-app/test-service/staging/",
+        environment_variables: environment_variables
+      )
+
+      visit infrastructure_environment_variables_path(infrastructure)
+
+      expect(page).to have_content(I18n.t("obfuscation"))
+
+      expect(page).not_to have_content("Create of update variable")
+
+      find(".secret-cell").click
+
+      expect(page).to have_content("BAAZ")
+      expect(page).not_to have_content(I18n.t("obfuscation"))
+    end
+  end
+
+  context "when the app is configured to SHOW secrets by default" do
+    around do |example|
+      ClimateControl.modify HIDE_SECRETS_BY_DEFAULT: "false" do
+        example.run
+      end
+    end
+
+    scenario "values are shown by default" do
+      environment_variable = create_aws_environment_variable(name: "FOO", value: "BAAZ")
+      environment_variables = Aws::SSM::Types::GetParametersByPathResult.new(
+        parameters: [environment_variable]
+      )
+
+      stub_call_to_aws_for_environment_variables(
+        account_id: infrastructure.account_id,
+        request_path: "/test-app/test-service/staging/",
+        environment_variables: environment_variables
+      )
+
+      visit infrastructure_environment_variables_path(infrastructure)
+
+      expect(page).not_to have_content(I18n.t("obfuscation"))
+      expect(page).to have_content("BAAZ")
+    end
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe ApplicationHelper, type: :helper do
 
       it "obfuscates the value by replacing it with *" do
         result = helper.present_sensitive_value("secret")
-        expect(result).to eql("************************************")
+        expect(result).to eql I18n.t("obfuscation")
       end
     end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -22,4 +22,32 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
     end
   end
+
+  describe "#present_sensitive_value" do
+    context "when the app is configured to HIDE secrets" do
+      around do |example|
+        ClimateControl.modify HIDE_SECRETS_BY_DEFAULT: "true" do
+          example.run
+        end
+      end
+
+      it "obfuscates the value by replacing it with *" do
+        result = helper.present_sensitive_value("secret")
+        expect(result).to eql("************************************")
+      end
+    end
+
+    context "when the app is configured to SHOW secrets" do
+      around do |example|
+        ClimateControl.modify HIDE_SECRETS_BY_DEFAULT: "false" do
+          example.run
+        end
+      end
+
+      it "obfuscates the value by replacing it with *" do
+        result = helper.present_sensitive_value("secret")
+        expect(result).to eql("secret")
+      end
+    end
+  end
 end


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

- secrets are hidden by default so there is less likely to be accidents with screen sharing on a call or in a demo
- secrets can be toggled into view by clicking the obfuscation in the table cell for now

## Screenshots of UI changes

![Screenshot 2020-09-23 at 14 52 43](https://user-images.githubusercontent.com/912473/94022190-bc164600-fdac-11ea-8f4e-2a76e960a81c.png)
![Screenshot 2020-09-23 at 14 52 52](https://user-images.githubusercontent.com/912473/94022194-bd477300-fdac-11ea-852d-e691ae5d3486.png)
## Next steps
