### PR TITLE
Infrastructure variables are shown for every infrastructure (not just those running on the core AWS account)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - users are shown a warning about the effect of using any action within the service
 - secret environment variables are hidden by default
 - secret environment variables can be shown and hidden individually by clicking the cell
+- infrastructure variables are shown for every infrastructure (not just those running on the core AWS account)
 
 [unreleased]: TODO
 [keep a changelog 1.0.0]: https://keepachangelog.com/en/1.0.0/

--- a/app/services/create_environment_variable.rb
+++ b/app/services/create_environment_variable.rb
@@ -9,11 +9,15 @@ class CreateEnvironmentVariable
   end
 
   def call
-    PutAwsParameter.new(infrastructure: infrastructure)
+    PutAwsParameter.new(aws_ssm_client: aws_ssm_client, infrastructure: infrastructure)
       .call(path: name_with_path, key_id: key_id, value: environment_variable.value)
   end
 
   private
+
+  def aws_ssm_client
+    ClientForInfrastructureAwsAccount.new(infrastructure: infrastructure).call
+  end
 
   def name_with_path
     "/#{infrastructure.identifier}/#{environment_variable.full_aws_name}"

--- a/app/services/create_infrastructure_variable.rb
+++ b/app/services/create_infrastructure_variable.rb
@@ -9,11 +9,15 @@ class CreateInfrastructureVariable
   end
 
   def call
-    PutAwsParameter.new(infrastructure: infrastructure)
+    PutAwsParameter.new(aws_ssm_client: aws_ssm_client, infrastructure: infrastructure)
       .call(path: name_with_path, key_id: key_id, value: infrastructure_variable.value)
   end
 
   private
+
+  def aws_ssm_client
+    ClientForCoreAwsAccount.new.call
+  end
 
   def name_with_path
     "/dalmatian-variables/infrastructures/#{infrastructure.identifier}/#{infrastructure_variable.environment_name}/#{infrastructure_variable.name}"

--- a/app/services/delete_aws_parameter.rb
+++ b/app/services/delete_aws_parameter.rb
@@ -1,9 +1,8 @@
 class DeleteAwsParameter
-  include AwsClientWrapper
+  attr_accessor :aws_ssm_client, :infrastructure
 
-  attr_accessor :infrastructure
-
-  def initialize(infrastructure:)
+  def initialize(aws_ssm_client:, infrastructure:)
+    self.aws_ssm_client = aws_ssm_client
     self.infrastructure = infrastructure
   end
 

--- a/app/services/delete_environment_variable.rb
+++ b/app/services/delete_environment_variable.rb
@@ -1,4 +1,6 @@
 class DeleteEnvironmentVariable
+  include AwsClientWrapper
+
   attr_accessor :infrastructure
 
   def initialize(infrastructure:)
@@ -8,7 +10,13 @@ class DeleteEnvironmentVariable
   def call(environment_variable:)
     full_name = "#{infrastructure.identifier}/#{environment_variable.full_aws_name}"
 
-    result = DeleteAwsParameter.new(infrastructure: infrastructure).call(path: full_name)
+    result = DeleteAwsParameter.new(aws_ssm_client: aws_ssm_client, infrastructure: infrastructure).call(path: full_name)
     result
+  end
+
+  private
+
+  def aws_ssm_client
+    ClientForInfrastructureAwsAccount.new(infrastructure: infrastructure).call
   end
 end

--- a/app/services/delete_infrastructure_variable.rb
+++ b/app/services/delete_infrastructure_variable.rb
@@ -1,4 +1,6 @@
 class DeleteInfrastructureVariable
+  include AwsClientWrapper
+
   attr_accessor :infrastructure
 
   def initialize(infrastructure:)
@@ -8,7 +10,13 @@ class DeleteInfrastructureVariable
   def call(infrastructure_variable:)
     full_name = "/dalmatian-variables/infrastructures/#{infrastructure.identifier}/#{infrastructure_variable.environment_name}/#{infrastructure_variable.name}"
 
-    result = DeleteAwsParameter.new(infrastructure: infrastructure).call(path: full_name)
+    result = DeleteAwsParameter.new(aws_ssm_client: aws_ssm_client, infrastructure: infrastructure).call(path: full_name)
     result
+  end
+
+  private
+
+  def aws_ssm_client
+    ClientForCoreAwsAccount.new.call
   end
 end

--- a/app/services/find_environment_variables.rb
+++ b/app/services/find_environment_variables.rb
@@ -1,4 +1,6 @@
 class FindEnvironmentVariables
+  include AwsClientWrapper
+
   attr_writer :infrastructure
 
   def initialize(infrastructure:)
@@ -14,7 +16,7 @@ class FindEnvironmentVariables
 
       infrastructure.environments.each do |environment_name, _blob|
         path = environment_variable_path(service_name: service_name, environment_name: environment_name)
-        results[service_name][environment_name] = GetAwsParameter.new(infrastructure: infrastructure, path: path).call
+        results[service_name][environment_name] = GetAwsParameter.new(aws_ssm_client: aws_ssm_client, path: path).call
       end
     end
 
@@ -24,6 +26,10 @@ class FindEnvironmentVariables
   private
 
   attr_reader :infrastructure
+
+  def aws_ssm_client
+    @aws_ssm_client ||= ClientForInfrastructureAwsAccount.new(infrastructure: infrastructure).call
+  end
 
   def environment_variable_path(service_name:, environment_name:)
     "/#{infrastructure.identifier}/#{service_name}/#{environment_name}/"

--- a/app/services/find_infrastructure_variables.rb
+++ b/app/services/find_infrastructure_variables.rb
@@ -1,5 +1,7 @@
 class FindInfrastructureVariables
-  attr_writer :infrastructure
+  include AwsClientWrapper
+
+  attr_accessor :infrastructure
 
   def initialize(infrastructure:)
     self.infrastructure = infrastructure
@@ -10,7 +12,7 @@ class FindInfrastructureVariables
 
     infrastructure.environments.each do |environment_name, _blob|
       path = infrastructure_variable_path(environment_name: environment_name)
-      results[environment_name] = GetAwsParameter.new(infrastructure: infrastructure, path: path).call
+      results[environment_name] = GetAwsParameter.new(aws_ssm_client: aws_ssm_client, path: path).call
     end
 
     results
@@ -18,7 +20,9 @@ class FindInfrastructureVariables
 
   private
 
-  attr_reader :infrastructure
+  def aws_ssm_client
+    @aws_ssm_client ||= ClientForCoreAwsAccount.new.call
+  end
 
   def infrastructure_variable_path(environment_name:)
     "/dalmatian-variables/infrastructures/#{infrastructure.identifier}/#{environment_name}/"

--- a/app/services/get_aws_parameter.rb
+++ b/app/services/get_aws_parameter.rb
@@ -1,10 +1,8 @@
 class GetAwsParameter
-  include AwsClientWrapper
+  attr_accessor :aws_ssm_client, :path
 
-  attr_accessor :infrastructure, :path
-
-  def initialize(infrastructure:, path:)
-    self.infrastructure = infrastructure
+  def initialize(aws_ssm_client:, path:)
+    self.aws_ssm_client = aws_ssm_client
     self.path = path
   end
 

--- a/app/services/put_aws_parameter.rb
+++ b/app/services/put_aws_parameter.rb
@@ -1,9 +1,8 @@
 class PutAwsParameter
-  include AwsClientWrapper
+  attr_accessor :aws_ssm_client, :infrastructure
 
-  attr_accessor :infrastructure
-
-  def initialize(infrastructure:)
+  def initialize(aws_ssm_client:, infrastructure:)
+    self.aws_ssm_client = aws_ssm_client
     self.infrastructure = infrastructure
   end
 

--- a/doc/architecture/decisions/0008-use-different-aws-account-for-interacting-with-infrastructure-variables.md
+++ b/doc/architecture/decisions/0008-use-different-aws-account-for-interacting-with-infrastructure-variables.md
@@ -1,0 +1,38 @@
+# 8. use-different-aws-account-for-interacting-with-infrastructure-variables
+
+Date: 2020-09-24
+
+## Status
+
+Accepted
+
+## Context
+
+The issue motivating this decision, and any context that influences or constrains the decision.
+
+Dalmatian stores variables in AWS Parameter store. Each infrastructure has an `account_id`
+associated with it which is used to manage which account variables are read, added and removed from - this is as you might expect.
+
+Dalmatian also stores another type of variable which the app has initially given
+the name of "infrastructure variable". These variables are NOT managed by the
+individual AWS accounts associated with each infrastructure. Rather they are all
+managed within a central AWS account and given a meaningful name space to relate
+it to a dependent service.
+
+For this apps purposes it would have been easier for all variables associated with
+a service to live in the same account. I believe there are restrictions to how
+Dalmatian itself (rather than the services there on) is deployed which has steered
+Dalmatian into being designed this way.
+
+## Decision
+
+Handle the complexity of 2 different types of AWS Client within the service rather
+than seeking to change the way infrastructure variables are provisioned to align
+with the infrastructure they belong to.
+
+## Consequences
+
+- The application will have complexity layered into it which makes it more
+complex which may make it harder to understand and work with.
+- Users of this service must align the way they managed their AWS Parameter store
+with the design of Dalmatian core

--- a/lib/aws_client_wrapper.rb
+++ b/lib/aws_client_wrapper.rb
@@ -1,26 +1,56 @@
 module AwsClientWrapper
-  def aws_role
-    ENV["AWS_ROLE"]
+  class Client
+    def call
+      Aws::SSM::Client.new(credentials: role_credentials)
+    end
+
+    private
+
+    def aws_role
+      ENV["AWS_ROLE"]
+    end
+
+    def role_session_name
+      # ! This is the value in GUI but it looks like it was intended to be 'dalmatian-environment-variables-gui'
+      @role_session_name ||= "role_session_name"
+    end
+
+    def role_credentials
+      @role_credentials ||= Aws::AssumeRoleCredentials.new(
+        client: core_aws_client,
+        role_arn: role_arn,
+        role_session_name: role_session_name
+      )
+    end
+
+    def core_aws_client
+      @core_aws_client ||= Aws::STS::Client.new
+    end
   end
 
-  def role_arn
-    @role_arn ||= "arn:aws:iam::#{infrastructure.account_id}:role/#{aws_role}"
+  class ClientForCoreAwsAccount < Client
+    include AwsClientWrapper
+
+    private def role_arn
+      "arn:aws:iam::#{core_aws_account_id}:role/#{aws_role}"
+    end
+
+    private def core_aws_account_id
+      Aws::STS::Client.new.get_caller_identity.account
+    end
   end
 
-  def role_session_name
-    # ! This is the value in GUI but it looks like it was intended to be 'dalmatian-environment-variables-gui'
-    @role_session_name ||= "role_session_name"
-  end
+  class ClientForInfrastructureAwsAccount < Client
+    include AwsClientWrapper
 
-  def role_credentials
-    @role_credentials ||= Aws::AssumeRoleCredentials.new(
-      client: Aws::STS::Client.new,
-      role_arn: role_arn,
-      role_session_name: role_session_name
-    )
-  end
+    attr_accessor :infrastructure
 
-  def aws_ssm_client
-    @aws_ssm_client ||= Aws::SSM::Client.new(credentials: role_credentials)
+    def initialize(infrastructure:)
+      self.infrastructure = infrastructure
+    end
+
+    private def role_arn
+      "arn:aws:iam::#{infrastructure.account_id}:role/#{aws_role}"
+    end
   end
 end

--- a/spec/features/users_can_add_a_new_environment_variable_spec.rb
+++ b/spec/features/users_can_add_a_new_environment_variable_spec.rb
@@ -10,7 +10,7 @@ feature "Users can add new environment variables" do
     aws_ssm_client = stub_aws_ssm_client(account_id: infrastructure.account_id)
 
     stub_call_to_aws_for_environment_variables(
-      aws_ssm_client_double: aws_ssm_client,
+      aws_ssm_client: aws_ssm_client,
       account_id: infrastructure.account_id,
       infrastructure_name: infrastructure.identifier,
       service_name: "test-service",
@@ -27,7 +27,7 @@ feature "Users can add new environment variables" do
     end
 
     stub_call_to_aws_to_update_environment_variables(
-      aws_ssm_client_double: aws_ssm_client,
+      aws_ssm_client: aws_ssm_client,
       account_id: infrastructure.account_id,
       infrastructure_identifier: infrastructure.identifier,
       service_name: "test-service",
@@ -42,7 +42,7 @@ feature "Users can add new environment variables" do
     )
 
     stub_call_to_aws_for_environment_variables(
-      aws_ssm_client_double: aws_ssm_client,
+      aws_ssm_client: aws_ssm_client,
       account_id: infrastructure.account_id,
       infrastructure_name: infrastructure.identifier,
       service_name: "test-service",
@@ -74,7 +74,7 @@ feature "Users can add new environment variables" do
     )
 
     stub_call_to_aws_for_environment_variables(
-      aws_ssm_client_double: aws_ssm_client,
+      aws_ssm_client: aws_ssm_client,
       account_id: infrastructure.account_id,
       infrastructure_name: infrastructure.identifier,
       service_name: "test-service",
@@ -95,7 +95,7 @@ feature "Users can add new environment variables" do
     end
 
     stub_call_to_aws_to_update_environment_variables(
-      aws_ssm_client_double: aws_ssm_client,
+      aws_ssm_client: aws_ssm_client,
       account_id: infrastructure.account_id,
       infrastructure_identifier: infrastructure.identifier,
       service_name: "test-service",
@@ -110,7 +110,7 @@ feature "Users can add new environment variables" do
     )
 
     stub_call_to_aws_for_environment_variables(
-      aws_ssm_client_double: aws_ssm_client,
+      aws_ssm_client: aws_ssm_client,
       account_id: infrastructure.account_id,
       infrastructure_name: infrastructure.identifier,
       service_name: "test-service",

--- a/spec/features/users_can_add_a_new_environment_variable_spec.rb
+++ b/spec/features/users_can_add_a_new_environment_variable_spec.rb
@@ -12,7 +12,9 @@ feature "Users can add new environment variables" do
     stub_call_to_aws_for_environment_variables(
       aws_ssm_client_double: aws_ssm_client,
       account_id: infrastructure.account_id,
-      request_path: "/test-app/test-service/staging/",
+      infrastructure_name: infrastructure.identifier,
+      service_name: "test-service",
+      environment_name: "staging",
       environment_variables: Aws::SSM::Types::GetParametersByPathResult.new(parameters: [])
     )
 
@@ -42,7 +44,9 @@ feature "Users can add new environment variables" do
     stub_call_to_aws_for_environment_variables(
       aws_ssm_client_double: aws_ssm_client,
       account_id: infrastructure.account_id,
-      request_path: "/test-app/test-service/staging/",
+      infrastructure_name: infrastructure.identifier,
+      service_name: "test-service",
+      environment_name: "staging",
       environment_variables: updated_environment_variables
     )
 
@@ -72,7 +76,9 @@ feature "Users can add new environment variables" do
     stub_call_to_aws_for_environment_variables(
       aws_ssm_client_double: aws_ssm_client,
       account_id: infrastructure.account_id,
-      request_path: "/test-app/test-service/staging/",
+      infrastructure_name: infrastructure.identifier,
+      service_name: "test-service",
+      environment_name: "staging",
       environment_variables: existing_environment_variables
     )
 
@@ -106,7 +112,9 @@ feature "Users can add new environment variables" do
     stub_call_to_aws_for_environment_variables(
       aws_ssm_client_double: aws_ssm_client,
       account_id: infrastructure.account_id,
-      request_path: "/test-app/test-service/staging/",
+      infrastructure_name: infrastructure.identifier,
+      service_name: "test-service",
+      environment_name: "staging",
       environment_variables: updated_environment_variables
     )
 

--- a/spec/features/users_can_add_a_new_infrastructure_variable_spec.rb
+++ b/spec/features/users_can_add_a_new_infrastructure_variable_spec.rb
@@ -1,4 +1,11 @@
 feature "Users can add new infrastructure variables" do
+  let(:aws_ssm_client) do
+    stub_aws_ssm_client(
+      aws_sts_client: stub_main_aws_sts_client,
+      account_id: AwsApiHelpers::CORE_AWS_ACCOUNT_ID
+    )
+  end
+
   scenario "adds a new variable" do
     infrastructure = Infrastructure.create(
       identifier: "test-app",
@@ -7,11 +14,8 @@ feature "Users can add new infrastructure variables" do
       environments: {"staging" => []}
     )
 
-    aws_ssm_client = stub_aws_ssm_client(account_id: infrastructure.account_id)
-
     stub_call_to_aws_for_infrastructure_variables(
-      aws_ssm_client_double: aws_ssm_client,
-      account_id: infrastructure.account_id,
+      aws_ssm_client: aws_ssm_client,
       service_name: "test-app",
       environment_name: "staging",
       environment_variables: Aws::SSM::Types::GetParametersByPathResult.new(parameters: [])
@@ -26,7 +30,7 @@ feature "Users can add new infrastructure variables" do
     end
 
     stub_call_to_aws_to_update_infrastructure_variables(
-      aws_ssm_client_double: aws_ssm_client,
+      aws_ssm_client: aws_ssm_client,
       account_id: infrastructure.account_id,
       infrastructure_identifier: infrastructure.identifier,
       environment_name: "staging",
@@ -40,8 +44,7 @@ feature "Users can add new infrastructure variables" do
     )
 
     stub_call_to_aws_for_infrastructure_variables(
-      aws_ssm_client_double: aws_ssm_client,
-      account_id: infrastructure.account_id,
+      aws_ssm_client: aws_ssm_client,
       service_name: "test-app",
       environment_name: "staging",
       environment_variables: updated_environment_variables
@@ -63,16 +66,13 @@ feature "Users can add new infrastructure variables" do
       environments: {"staging" => []}
     )
 
-    aws_ssm_client = stub_aws_ssm_client(account_id: infrastructure.account_id)
-
     existing_environment_variable = create_aws_environment_variable(name: "EXISTING_VARIABLE_NAME", value: "EXISTING_VARIABLE_VALUE")
     existing_environment_variables = Aws::SSM::Types::GetParametersByPathResult.new(
       parameters: [existing_environment_variable]
     )
 
     stub_call_to_aws_for_infrastructure_variables(
-      aws_ssm_client_double: aws_ssm_client,
-      account_id: infrastructure.account_id,
+      aws_ssm_client: aws_ssm_client,
       service_name: "test-app",
       environment_name: "staging",
       environment_variables: existing_environment_variables
@@ -91,7 +91,7 @@ feature "Users can add new infrastructure variables" do
     end
 
     stub_call_to_aws_to_update_infrastructure_variables(
-      aws_ssm_client_double: aws_ssm_client,
+      aws_ssm_client: aws_ssm_client,
       account_id: infrastructure.account_id,
       infrastructure_identifier: infrastructure.identifier,
       environment_name: "staging",
@@ -105,8 +105,7 @@ feature "Users can add new infrastructure variables" do
     )
 
     stub_call_to_aws_for_infrastructure_variables(
-      aws_ssm_client_double: aws_ssm_client,
-      account_id: infrastructure.account_id,
+      aws_ssm_client: aws_ssm_client,
       service_name: "test-app",
       environment_name: "staging",
       environment_variables: updated_environment_variables

--- a/spec/features/users_can_add_a_new_infrastructure_variable_spec.rb
+++ b/spec/features/users_can_add_a_new_infrastructure_variable_spec.rb
@@ -9,7 +9,7 @@ feature "Users can add new infrastructure variables" do
 
     aws_ssm_client = stub_aws_ssm_client(account_id: infrastructure.account_id)
 
-    stub_call_to_aws_for_environment_variables(
+    stub_call_to_aws_for_infrastructure_variables(
       aws_ssm_client_double: aws_ssm_client,
       account_id: infrastructure.account_id,
       request_path: "/dalmatian-variables/infrastructures/test-app/staging/",
@@ -38,7 +38,7 @@ feature "Users can add new infrastructure variables" do
       parameters: [updated_environment_variable]
     )
 
-    stub_call_to_aws_for_environment_variables(
+    stub_call_to_aws_for_infrastructure_variables(
       aws_ssm_client_double: aws_ssm_client,
       account_id: infrastructure.account_id,
       request_path: "/dalmatian-variables/infrastructures/test-app/staging/",
@@ -68,7 +68,7 @@ feature "Users can add new infrastructure variables" do
       parameters: [existing_environment_variable]
     )
 
-    stub_call_to_aws_for_environment_variables(
+    stub_call_to_aws_for_infrastructure_variables(
       aws_ssm_client_double: aws_ssm_client,
       account_id: infrastructure.account_id,
       request_path: "/dalmatian-variables/infrastructures/test-app/staging/",
@@ -101,7 +101,7 @@ feature "Users can add new infrastructure variables" do
       parameters: [updated_environment_variable]
     )
 
-    stub_call_to_aws_for_environment_variables(
+    stub_call_to_aws_for_infrastructure_variables(
       aws_ssm_client_double: aws_ssm_client,
       account_id: infrastructure.account_id,
       request_path: "/dalmatian-variables/infrastructures/test-app/staging/",

--- a/spec/features/users_can_add_a_new_infrastructure_variable_spec.rb
+++ b/spec/features/users_can_add_a_new_infrastructure_variable_spec.rb
@@ -12,7 +12,8 @@ feature "Users can add new infrastructure variables" do
     stub_call_to_aws_for_infrastructure_variables(
       aws_ssm_client_double: aws_ssm_client,
       account_id: infrastructure.account_id,
-      request_path: "/dalmatian-variables/infrastructures/test-app/staging/",
+      service_name: "test-app",
+      environment_name: "staging",
       environment_variables: Aws::SSM::Types::GetParametersByPathResult.new(parameters: [])
     )
 
@@ -41,7 +42,8 @@ feature "Users can add new infrastructure variables" do
     stub_call_to_aws_for_infrastructure_variables(
       aws_ssm_client_double: aws_ssm_client,
       account_id: infrastructure.account_id,
-      request_path: "/dalmatian-variables/infrastructures/test-app/staging/",
+      service_name: "test-app",
+      environment_name: "staging",
       environment_variables: updated_environment_variables
     )
 
@@ -71,7 +73,8 @@ feature "Users can add new infrastructure variables" do
     stub_call_to_aws_for_infrastructure_variables(
       aws_ssm_client_double: aws_ssm_client,
       account_id: infrastructure.account_id,
-      request_path: "/dalmatian-variables/infrastructures/test-app/staging/",
+      service_name: "test-app",
+      environment_name: "staging",
       environment_variables: existing_environment_variables
     )
 
@@ -104,7 +107,8 @@ feature "Users can add new infrastructure variables" do
     stub_call_to_aws_for_infrastructure_variables(
       aws_ssm_client_double: aws_ssm_client,
       account_id: infrastructure.account_id,
-      request_path: "/dalmatian-variables/infrastructures/test-app/staging/",
+      service_name: "test-app",
+      environment_name: "staging",
       environment_variables: updated_environment_variables
     )
 

--- a/spec/features/users_can_delete_an_environment_variable_spec.rb
+++ b/spec/features/users_can_delete_an_environment_variable_spec.rb
@@ -16,7 +16,7 @@ feature "Users can delete environment variables" do
     )
 
     stub_call_to_aws_for_environment_variables(
-      aws_ssm_client_double: aws_ssm_client,
+      aws_ssm_client: aws_ssm_client,
       account_id: infrastructure.account_id,
       infrastructure_name: infrastructure.identifier,
       service_name: "test-service",
@@ -25,7 +25,7 @@ feature "Users can delete environment variables" do
     )
 
     stub_call_to_aws_to_delete_environment_variable(
-      aws_ssm_client_double: aws_ssm_client,
+      aws_ssm_client: aws_ssm_client,
       account_id: infrastructure.account_id,
       infrastructure_name: infrastructure.identifier,
       service_name: "test-service",
@@ -36,7 +36,7 @@ feature "Users can delete environment variables" do
     visit infrastructure_environment_variables_path(infrastructure)
 
     stub_call_to_aws_for_environment_variables(
-      aws_ssm_client_double: aws_ssm_client,
+      aws_ssm_client: aws_ssm_client,
       account_id: infrastructure.account_id,
       infrastructure_name: infrastructure.identifier,
       service_name: "test-service",

--- a/spec/features/users_can_delete_an_environment_variable_spec.rb
+++ b/spec/features/users_can_delete_an_environment_variable_spec.rb
@@ -18,7 +18,9 @@ feature "Users can delete environment variables" do
     stub_call_to_aws_for_environment_variables(
       aws_ssm_client_double: aws_ssm_client,
       account_id: infrastructure.account_id,
-      request_path: "/test-app/test-service/staging/",
+      infrastructure_name: infrastructure.identifier,
+      service_name: "test-service",
+      environment_name: "staging",
       environment_variables: existing_environment_variables
     )
 
@@ -34,7 +36,9 @@ feature "Users can delete environment variables" do
     stub_call_to_aws_for_environment_variables(
       aws_ssm_client_double: aws_ssm_client,
       account_id: infrastructure.account_id,
-      request_path: "/test-app/test-service/staging/",
+      infrastructure_name: infrastructure.identifier,
+      service_name: "test-service",
+      environment_name: "staging",
       environment_variables: Aws::SSM::Types::GetParametersByPathResult.new(parameters: [])
     )
 

--- a/spec/features/users_can_delete_an_environment_variable_spec.rb
+++ b/spec/features/users_can_delete_an_environment_variable_spec.rb
@@ -27,8 +27,10 @@ feature "Users can delete environment variables" do
     stub_call_to_aws_to_delete_environment_variable(
       aws_ssm_client_double: aws_ssm_client,
       account_id: infrastructure.account_id,
-      request_path: "test-app/test-service/staging",
-      name: "EXISTING_VARIABLE_NAME"
+      infrastructure_name: infrastructure.identifier,
+      service_name: "test-service",
+      environment_name: "staging",
+      variable_name: "EXISTING_VARIABLE_NAME"
     )
 
     visit infrastructure_environment_variables_path(infrastructure)

--- a/spec/features/users_can_delete_an_infrastructure_variable_spec.rb
+++ b/spec/features/users_can_delete_an_infrastructure_variable_spec.rb
@@ -26,8 +26,9 @@ feature "Users can delete infrastructure variables" do
     stub_call_to_aws_to_delete_infrastructure_variable(
       aws_ssm_client_double: aws_ssm_client,
       account_id: infrastructure.account_id,
-      request_path: "/dalmatian-variables/infrastructures/test-app/staging",
-      name: "EXISTING_VARIABLE_NAME"
+      service_name: "test-app",
+      environment_name: "staging",
+      variable_name: "EXISTING_VARIABLE_NAME"
     )
 
     visit infrastructure_variables_path(infrastructure)

--- a/spec/features/users_can_delete_an_infrastructure_variable_spec.rb
+++ b/spec/features/users_can_delete_an_infrastructure_variable_spec.rb
@@ -15,7 +15,7 @@ feature "Users can delete infrastructure variables" do
       parameters: [existing_environment_variable]
     )
 
-    stub_call_to_aws_for_environment_variables(
+    stub_call_to_aws_for_infrastructure_variables(
       aws_ssm_client_double: aws_ssm_client,
       account_id: infrastructure.account_id,
       request_path: "/dalmatian-variables/infrastructures/test-app/staging/",
@@ -31,7 +31,7 @@ feature "Users can delete infrastructure variables" do
 
     visit infrastructure_variables_path(infrastructure)
 
-    stub_call_to_aws_for_environment_variables(
+    stub_call_to_aws_for_infrastructure_variables(
       aws_ssm_client_double: aws_ssm_client,
       account_id: infrastructure.account_id,
       request_path: "/dalmatian-variables/infrastructures/test-app/staging/",

--- a/spec/features/users_can_delete_an_infrastructure_variable_spec.rb
+++ b/spec/features/users_can_delete_an_infrastructure_variable_spec.rb
@@ -23,7 +23,7 @@ feature "Users can delete infrastructure variables" do
       environment_variables: existing_environment_variables
     )
 
-    stub_call_to_aws_to_delete_environment_variable(
+    stub_call_to_aws_to_delete_infrastructure_variable(
       aws_ssm_client_double: aws_ssm_client,
       account_id: infrastructure.account_id,
       request_path: "/dalmatian-variables/infrastructures/test-app/staging",

--- a/spec/features/users_can_delete_an_infrastructure_variable_spec.rb
+++ b/spec/features/users_can_delete_an_infrastructure_variable_spec.rb
@@ -18,7 +18,8 @@ feature "Users can delete infrastructure variables" do
     stub_call_to_aws_for_infrastructure_variables(
       aws_ssm_client_double: aws_ssm_client,
       account_id: infrastructure.account_id,
-      request_path: "/dalmatian-variables/infrastructures/test-app/staging/",
+      service_name: "test-app",
+      environment_name: "staging",
       environment_variables: existing_environment_variables
     )
 
@@ -34,7 +35,8 @@ feature "Users can delete infrastructure variables" do
     stub_call_to_aws_for_infrastructure_variables(
       aws_ssm_client_double: aws_ssm_client,
       account_id: infrastructure.account_id,
-      request_path: "/dalmatian-variables/infrastructures/test-app/staging/",
+      service_name: "test-app",
+      environment_name: "staging",
       environment_variables: Aws::SSM::Types::GetParametersByPathResult.new(parameters: [])
     )
 

--- a/spec/features/users_can_delete_an_infrastructure_variable_spec.rb
+++ b/spec/features/users_can_delete_an_infrastructure_variable_spec.rb
@@ -7,7 +7,7 @@ feature "Users can delete infrastructure variables" do
       environments: {"staging" => []}
     )
   end
-  let(:aws_ssm_client) { stub_aws_ssm_client(account_id: infrastructure.account_id) }
+  let(:aws_ssm_client) { stub_aws_ssm_client(aws_sts_client: stub_main_aws_sts_client, account_id: AwsApiHelpers::CORE_AWS_ACCOUNT_ID) }
 
   scenario "delete a single variable", js: true do
     existing_environment_variable = create_aws_environment_variable(name: "EXISTING_VARIABLE_NAME", value: "EXISTING_VARIABLE_VALUE")
@@ -16,15 +16,14 @@ feature "Users can delete infrastructure variables" do
     )
 
     stub_call_to_aws_for_infrastructure_variables(
-      aws_ssm_client_double: aws_ssm_client,
-      account_id: infrastructure.account_id,
+      aws_ssm_client: aws_ssm_client,
       service_name: "test-app",
       environment_name: "staging",
       environment_variables: existing_environment_variables
     )
 
     stub_call_to_aws_to_delete_infrastructure_variable(
-      aws_ssm_client_double: aws_ssm_client,
+      aws_ssm_client: aws_ssm_client,
       account_id: infrastructure.account_id,
       service_name: "test-app",
       environment_name: "staging",
@@ -34,8 +33,7 @@ feature "Users can delete infrastructure variables" do
     visit infrastructure_variables_path(infrastructure)
 
     stub_call_to_aws_for_infrastructure_variables(
-      aws_ssm_client_double: aws_ssm_client,
-      account_id: infrastructure.account_id,
+      aws_ssm_client: aws_ssm_client,
       service_name: "test-app",
       environment_name: "staging",
       environment_variables: Aws::SSM::Types::GetParametersByPathResult.new(parameters: [])

--- a/spec/features/users_can_see_environment_variables_spec.rb
+++ b/spec/features/users_can_see_environment_variables_spec.rb
@@ -14,7 +14,9 @@ feature "Users can see environment variables" do
 
     stub_call_to_aws_for_environment_variables(
       account_id: infrastructure.account_id,
-      request_path: "/test-app/test-service/staging/",
+      infrastructure_name: infrastructure.identifier,
+      service_name: "test-service",
+      environment_name: "staging",
       environment_variables: fake_environment_variables
     )
 

--- a/spec/features/users_can_see_infrastructure_variables_spec.rb
+++ b/spec/features/users_can_see_infrastructure_variables_spec.rb
@@ -13,7 +13,8 @@ feature "Users can see infrastructure variables" do
 
     stub_call_to_aws_for_infrastructure_variables(
       account_id: infrastructure.account_id,
-      request_path: "/dalmatian-variables/infrastructures/test-app/staging/",
+      service_name: "test-app",
+      environment_name: "staging",
       environment_variables: fake_environment_variables
     )
 

--- a/spec/features/users_can_see_infrastructure_variables_spec.rb
+++ b/spec/features/users_can_see_infrastructure_variables_spec.rb
@@ -11,7 +11,7 @@ feature "Users can see infrastructure variables" do
       fake_environment_variable
     ])
 
-    stub_call_to_aws_for_environment_variables(
+    stub_call_to_aws_for_infrastructure_variables(
       account_id: infrastructure.account_id,
       request_path: "/dalmatian-variables/infrastructures/test-app/staging/",
       environment_variables: fake_environment_variables

--- a/spec/features/users_can_see_infrastructure_variables_spec.rb
+++ b/spec/features/users_can_see_infrastructure_variables_spec.rb
@@ -12,7 +12,6 @@ feature "Users can see infrastructure variables" do
     ])
 
     stub_call_to_aws_for_infrastructure_variables(
-      account_id: infrastructure.account_id,
       service_name: "test-app",
       environment_name: "staging",
       environment_variables: fake_environment_variables

--- a/spec/features/users_show_and_hide_secret_variables_spec.rb
+++ b/spec/features/users_show_and_hide_secret_variables_spec.rb
@@ -23,7 +23,9 @@ feature "Users can show and hide secret variables" do
 
       stub_call_to_aws_for_environment_variables(
         account_id: infrastructure.account_id,
-        request_path: "/test-app/test-service/staging/",
+        infrastructure_name: infrastructure.identifier,
+        service_name: "test-service",
+        environment_name: "staging",
         environment_variables: environment_variables
       )
 
@@ -41,7 +43,9 @@ feature "Users can show and hide secret variables" do
 
       stub_call_to_aws_for_environment_variables(
         account_id: infrastructure.account_id,
-        request_path: "/test-app/test-service/staging/",
+        infrastructure_name: infrastructure.identifier,
+        service_name: "test-service",
+        environment_name: "staging",
         environment_variables: environment_variables
       )
 
@@ -73,7 +77,9 @@ feature "Users can show and hide secret variables" do
 
       stub_call_to_aws_for_environment_variables(
         account_id: infrastructure.account_id,
-        request_path: "/test-app/test-service/staging/",
+        infrastructure_name: infrastructure.identifier,
+        service_name: "test-service",
+        environment_name: "staging",
         environment_variables: environment_variables
       )
 

--- a/spec/services/delete_aws_parameter_spec.rb
+++ b/spec/services/delete_aws_parameter_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe DeleteAwsParameter do
     it "returns an object with the new parameter version number" do
       infrastructure = Infrastructure.new(account_id: "345")
 
-      stub_call_to_aws_to_delete_environment_variable(
+      stub_call_to_aws_to_delete_infrastructure_variable(
         account_id: infrastructure.account_id,
         request_path: "/dalmatian-variables/infrastructures/test-app/staging",
         name: "EXISTING_VARIABLE_NAME"

--- a/spec/services/delete_aws_parameter_spec.rb
+++ b/spec/services/delete_aws_parameter_spec.rb
@@ -7,8 +7,9 @@ RSpec.describe DeleteAwsParameter do
 
       stub_call_to_aws_to_delete_infrastructure_variable(
         account_id: infrastructure.account_id,
-        request_path: "/dalmatian-variables/infrastructures/test-app/staging",
-        name: "EXISTING_VARIABLE_NAME"
+        service_name: "test-app",
+        environment_name: "staging",
+        variable_name: "EXISTING_VARIABLE_NAME"
       )
 
       expected_request_path = "/dalmatian-variables/infrastructures/test-app/staging/EXISTING_VARIABLE_NAME"

--- a/spec/services/delete_aws_parameter_spec.rb
+++ b/spec/services/delete_aws_parameter_spec.rb
@@ -2,10 +2,13 @@ require "rails_helper"
 
 RSpec.describe DeleteAwsParameter do
   describe "#call" do
+    let(:aws_ssm_client) { stub_aws_ssm_client(account_id: AwsApiHelpers::CORE_AWS_ACCOUNT_ID) }
+
     it "returns an object with the new parameter version number" do
       infrastructure = Infrastructure.new(account_id: "345")
 
       stub_call_to_aws_to_delete_infrastructure_variable(
+        aws_ssm_client: aws_ssm_client,
         account_id: infrastructure.account_id,
         service_name: "test-app",
         environment_name: "staging",
@@ -14,7 +17,7 @@ RSpec.describe DeleteAwsParameter do
 
       expected_request_path = "/dalmatian-variables/infrastructures/test-app/staging/EXISTING_VARIABLE_NAME"
 
-      result = described_class.new(infrastructure: infrastructure)
+      result = described_class.new(aws_ssm_client: aws_ssm_client, infrastructure: infrastructure)
         .call(path: expected_request_path)
 
       expect(result).to be_kind_of(Result)

--- a/spec/services/delete_infrastructure_variable_spec.rb
+++ b/spec/services/delete_infrastructure_variable_spec.rb
@@ -10,7 +10,12 @@ RSpec.describe DeleteInfrastructureVariable do
     )
   end
 
-  let(:aws_ssm_client) { stub_aws_ssm_client(account_id: infrastructure.account_id) }
+  let(:aws_ssm_client) do
+    stub_aws_ssm_client(
+      aws_sts_client: stub_main_aws_sts_client,
+      account_id: AwsApiHelpers::CORE_AWS_ACCOUNT_ID
+    )
+  end
 
   describe "#call" do
     it "sends a delete request to AWS" do

--- a/spec/services/delete_infrastructure_variable_spec.rb
+++ b/spec/services/delete_infrastructure_variable_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe DeleteInfrastructureVariable do
+  let(:infrastructure) do
+    Infrastructure.create(
+      identifier: "test-app",
+      account_id: "345",
+      services: [{"name" => "test-service"}],
+      environments: {"staging" => []}
+    )
+  end
+
+  let(:aws_ssm_client) { stub_aws_ssm_client(account_id: infrastructure.account_id) }
+
+  describe "#call" do
+    it "sends a delete request to AWS" do
+      infrastructure_variable = InfrastructureVariable.new(
+        name: "FOO",
+        environment_name: "BAZ"
+      )
+
+      expect(aws_ssm_client).to receive(:delete_parameter)
+        .with(name: "/dalmatian-variables/infrastructures/#{infrastructure.identifier}/#{infrastructure_variable.environment_name}/#{infrastructure_variable.name}")
+
+      result = described_class.new(infrastructure: infrastructure)
+        .call(infrastructure_variable: infrastructure_variable)
+
+      expect(result.success?).to eq(true)
+    end
+
+    context "when AWS errors with parameter not found" do
+      it "returns a failed result object" do
+        infrastructure_variable = InfrastructureVariable.new(
+          name: "FOO",
+          environment_name: "BAZ"
+        )
+
+        allow(aws_ssm_client).to receive(:delete_parameter)
+          .with(name: "/dalmatian-variables/infrastructures/#{infrastructure.identifier}/#{infrastructure_variable.environment_name}/#{infrastructure_variable.name}")
+          .and_raise(Aws::SSM::Errors::ParameterNotFound.new(anything, "Not found"))
+
+        result = described_class.new(infrastructure: infrastructure)
+          .call(infrastructure_variable: infrastructure_variable)
+
+        expect(result.success?).to eq(false)
+        expect(result.error_message).to eq("Parameter was not found")
+      end
+    end
+  end
+end

--- a/spec/services/find_environment_variables_spec.rb
+++ b/spec/services/find_environment_variables_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe FindEnvironmentVariables do
 
         aws_ssm_client = stub_aws_ssm_client(account_id: infrastructure.account_id)
         stub_call_to_aws_for_environment_variables(
-          aws_ssm_client_double: aws_ssm_client,
+          aws_ssm_client: aws_ssm_client,
           account_id: infrastructure.account_id,
           infrastructure_name: infrastructure.identifier,
           service_name: "first-service",
@@ -63,7 +63,7 @@ RSpec.describe FindEnvironmentVariables do
         )
 
         stub_call_to_aws_for_environment_variables(
-          aws_ssm_client_double: aws_ssm_client,
+          aws_ssm_client: aws_ssm_client,
           account_id: infrastructure.account_id,
           infrastructure_name: infrastructure.identifier,
           service_name: "first-service",
@@ -72,7 +72,7 @@ RSpec.describe FindEnvironmentVariables do
         )
 
         stub_call_to_aws_for_environment_variables(
-          aws_ssm_client_double: aws_ssm_client,
+          aws_ssm_client: aws_ssm_client,
           account_id: infrastructure.account_id,
           infrastructure_name: infrastructure.identifier,
           service_name: "second-service",
@@ -81,7 +81,7 @@ RSpec.describe FindEnvironmentVariables do
         )
 
         stub_call_to_aws_for_environment_variables(
-          aws_ssm_client_double: aws_ssm_client,
+          aws_ssm_client: aws_ssm_client,
           account_id: infrastructure.account_id,
           infrastructure_name: infrastructure.identifier,
           service_name: "second-service",

--- a/spec/services/find_environment_variables_spec.rb
+++ b/spec/services/find_environment_variables_spec.rb
@@ -17,7 +17,9 @@ RSpec.describe FindEnvironmentVariables do
 
       stub_call_to_aws_for_environment_variables(
         account_id: infrastructure.account_id,
-        request_path: "/test/test-service/staging/",
+        infrastructure_name: infrastructure.identifier,
+        service_name: "test-service",
+        environment_name: "staging",
         environment_variables: fake_environment_variables
       )
 
@@ -52,30 +54,38 @@ RSpec.describe FindEnvironmentVariables do
 
         aws_ssm_client = stub_aws_ssm_client(account_id: infrastructure.account_id)
         stub_call_to_aws_for_environment_variables(
-          account_id: infrastructure.account_id,
           aws_ssm_client_double: aws_ssm_client,
-          request_path: "/test/first-service/staging/",
+          account_id: infrastructure.account_id,
+          infrastructure_name: infrastructure.identifier,
+          service_name: "first-service",
+          environment_name: "staging",
           environment_variables: fake_environment_variables
         )
 
         stub_call_to_aws_for_environment_variables(
-          account_id: infrastructure.account_id,
           aws_ssm_client_double: aws_ssm_client,
-          request_path: "/test/first-service/production/",
+          account_id: infrastructure.account_id,
+          infrastructure_name: infrastructure.identifier,
+          service_name: "first-service",
+          environment_name: "production",
           environment_variables: fake_environment_variables
         )
 
         stub_call_to_aws_for_environment_variables(
-          account_id: infrastructure.account_id,
           aws_ssm_client_double: aws_ssm_client,
-          request_path: "/test/second-service/staging/",
+          account_id: infrastructure.account_id,
+          infrastructure_name: infrastructure.identifier,
+          service_name: "second-service",
+          environment_name: "staging",
           environment_variables: fake_environment_variables
         )
 
         stub_call_to_aws_for_environment_variables(
-          account_id: infrastructure.account_id,
           aws_ssm_client_double: aws_ssm_client,
-          request_path: "/test/second-service/production/",
+          account_id: infrastructure.account_id,
+          infrastructure_name: infrastructure.identifier,
+          service_name: "second-service",
+          environment_name: "production",
           environment_variables: fake_environment_variables
         )
 

--- a/spec/services/find_infrastructure_variables_spec.rb
+++ b/spec/services/find_infrastructure_variables_spec.rb
@@ -2,6 +2,13 @@ require "rails_helper"
 
 RSpec.describe FindInfrastructureVariables do
   describe "#call" do
+    let(:aws_ssm_client) do
+      stub_aws_ssm_client(
+        aws_sts_client: stub_main_aws_sts_client,
+        account_id: AwsApiHelpers::CORE_AWS_ACCOUNT_ID
+      )
+    end
+
     it "returns a hash of infrastructure variables grouped by environment" do
       infrastructure = Infrastructure.new(
         identifier: "test",
@@ -15,7 +22,6 @@ RSpec.describe FindInfrastructureVariables do
       )
 
       stub_call_to_aws_for_infrastructure_variables(
-        account_id: infrastructure.account_id,
         service_name: "test",
         environment_name: "staging",
         environment_variables: fake_environment_variables
@@ -44,18 +50,15 @@ RSpec.describe FindInfrastructureVariables do
           parameters: [fake_environment_variable]
         )
 
-        aws_ssm_client = stub_aws_ssm_client(account_id: infrastructure.account_id)
         stub_call_to_aws_for_infrastructure_variables(
-          account_id: infrastructure.account_id,
-          aws_ssm_client_double: aws_ssm_client,
+          aws_ssm_client: aws_ssm_client,
           service_name: "test",
           environment_name: "staging",
           environment_variables: fake_environment_variables
         )
 
         stub_call_to_aws_for_infrastructure_variables(
-          account_id: infrastructure.account_id,
-          aws_ssm_client_double: aws_ssm_client,
+          aws_ssm_client: aws_ssm_client,
           service_name: "test",
           environment_name: "production",
           environment_variables: fake_environment_variables

--- a/spec/services/find_infrastructure_variables_spec.rb
+++ b/spec/services/find_infrastructure_variables_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe FindInfrastructureVariables do
 
       stub_call_to_aws_for_infrastructure_variables(
         account_id: infrastructure.account_id,
-        request_path: "/dalmatian-variables/infrastructures/test/staging/",
+        service_name: "test",
+        environment_name: "staging",
         environment_variables: fake_environment_variables
       )
 
@@ -47,14 +48,16 @@ RSpec.describe FindInfrastructureVariables do
         stub_call_to_aws_for_infrastructure_variables(
           account_id: infrastructure.account_id,
           aws_ssm_client_double: aws_ssm_client,
-          request_path: "/dalmatian-variables/infrastructures/test/staging/",
+          service_name: "test",
+          environment_name: "staging",
           environment_variables: fake_environment_variables
         )
 
         stub_call_to_aws_for_infrastructure_variables(
           account_id: infrastructure.account_id,
           aws_ssm_client_double: aws_ssm_client,
-          request_path: "/dalmatian-variables/infrastructures/test/production/",
+          service_name: "test",
+          environment_name: "production",
           environment_variables: fake_environment_variables
         )
 

--- a/spec/services/find_infrastructure_variables_spec.rb
+++ b/spec/services/find_infrastructure_variables_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe FindInfrastructureVariables do
         parameters: [fake_environment_variable]
       )
 
-      stub_call_to_aws_for_environment_variables(
+      stub_call_to_aws_for_infrastructure_variables(
         account_id: infrastructure.account_id,
         request_path: "/dalmatian-variables/infrastructures/test/staging/",
         environment_variables: fake_environment_variables
@@ -44,14 +44,14 @@ RSpec.describe FindInfrastructureVariables do
         )
 
         aws_ssm_client = stub_aws_ssm_client(account_id: infrastructure.account_id)
-        stub_call_to_aws_for_environment_variables(
+        stub_call_to_aws_for_infrastructure_variables(
           account_id: infrastructure.account_id,
           aws_ssm_client_double: aws_ssm_client,
           request_path: "/dalmatian-variables/infrastructures/test/staging/",
           environment_variables: fake_environment_variables
         )
 
-        stub_call_to_aws_for_environment_variables(
+        stub_call_to_aws_for_infrastructure_variables(
           account_id: infrastructure.account_id,
           aws_ssm_client_double: aws_ssm_client,
           request_path: "/dalmatian-variables/infrastructures/test/production/",

--- a/spec/services/get_aws_parameter_spec.rb
+++ b/spec/services/get_aws_parameter_spec.rb
@@ -1,7 +1,11 @@
 require "rails_helper"
 
 RSpec.describe GetAwsParameter do
+  include AwsClientWrapper
+
   describe "#call" do
+    let(:aws_ssm_client) { stub_aws_ssm_client(account_id: "345") }
+
     it "returns a hash of variables grouped by environment" do
       infrastructure = Infrastructure.new(account_id: "345", identifier: "fee")
 
@@ -11,6 +15,7 @@ RSpec.describe GetAwsParameter do
       )
 
       stub_call_to_aws_for_environment_variables(
+        aws_ssm_client: aws_ssm_client,
         account_id: infrastructure.account_id,
         infrastructure_name: infrastructure.identifier,
         service_name: "bar",
@@ -20,7 +25,7 @@ RSpec.describe GetAwsParameter do
 
       expected_request_path = "/fee/bar/baz/"
 
-      result = described_class.new(infrastructure: infrastructure, path: expected_request_path).call
+      result = described_class.new(aws_ssm_client: aws_ssm_client, path: expected_request_path).call
 
       expect(result).to eq([fake_environment_variable])
     end

--- a/spec/services/get_aws_parameter_spec.rb
+++ b/spec/services/get_aws_parameter_spec.rb
@@ -2,9 +2,8 @@ require "rails_helper"
 
 RSpec.describe GetAwsParameter do
   describe "#call" do
-    it "returns a hash of infrastructure variables grouped by environment" do
-      infrastructure = Infrastructure.new(account_id: "345")
-      expected_request_path = "/foo/bar/baz"
+    it "returns a hash of variables grouped by environment" do
+      infrastructure = Infrastructure.new(account_id: "345", identifier: "fee")
 
       fake_environment_variable = create_aws_environment_variable(name: "FOO", value: "BAR")
       fake_environment_variables = Aws::SSM::Types::GetParametersByPathResult.new(
@@ -13,9 +12,13 @@ RSpec.describe GetAwsParameter do
 
       stub_call_to_aws_for_environment_variables(
         account_id: infrastructure.account_id,
-        request_path: expected_request_path,
+        infrastructure_name: infrastructure.identifier,
+        service_name: "bar",
+        environment_name: "baz",
         environment_variables: fake_environment_variables
       )
+
+      expected_request_path = "/fee/bar/baz/"
 
       result = described_class.new(infrastructure: infrastructure, path: expected_request_path).call
 

--- a/spec/services/put_aws_parameter_spec.rb
+++ b/spec/services/put_aws_parameter_spec.rb
@@ -2,12 +2,15 @@ require "rails_helper"
 
 RSpec.describe PutAwsParameter do
   describe "#call" do
+    let(:infrastructure) { Infrastructure.new(account_id: "345") }
+    let(:aws_ssm_client) { stub_aws_ssm_client(account_id: infrastructure.account_id) }
+
     it "asks AWS to update the variable" do
-      infrastructure = Infrastructure.new(account_id: "345")
       expected_request_path = "/foo/bar/baz/FOO"
       expected_key_id = "alias/foo-bar-baz-ssm"
 
       stub_call_to_aws_to_update_environment_variables(
+        aws_ssm_client: aws_ssm_client,
         account_id: infrastructure.account_id,
         infrastructure_identifier: "foo",
         service_name: "bar",
@@ -17,6 +20,7 @@ RSpec.describe PutAwsParameter do
       )
 
       result = described_class.new(
+        aws_ssm_client: aws_ssm_client,
         infrastructure: infrastructure
       ).call(
         path: expected_request_path,

--- a/spec/support/aws_api_helpers.rb
+++ b/spec/support/aws_api_helpers.rb
@@ -122,6 +122,21 @@ module AwsApiHelpers
       .with(name: full_name)
   end
 
+  def stub_call_to_aws_to_delete_infrastructure_variable(
+    aws_ssm_client_double: nil,
+    account_id:,
+    request_path:,
+    name:
+  )
+
+    aws_ssm_client = aws_ssm_client_double || stub_aws_ssm_client(account_id: account_id)
+
+    full_name = "#{request_path}/#{name}"
+    allow(aws_ssm_client)
+      .to receive(:delete_parameter)
+      .with(name: full_name)
+  end
+
   def stub_aws_ssm_client(account_id:)
     credentials = instance_double(Aws::AssumeRoleCredentials)
     allow(Aws::AssumeRoleCredentials).to receive(:new).with(

--- a/spec/support/aws_api_helpers.rb
+++ b/spec/support/aws_api_helpers.rb
@@ -14,12 +14,15 @@ module AwsApiHelpers
   end
 
   def stub_call_to_aws_for_environment_variables(
-    account_id:,
     aws_ssm_client_double: nil,
-    request_path:,
+    account_id:,
+    infrastructure_name:,
+    service_name:,
+    environment_name:,
     environment_variables:
   )
     aws_ssm_client = aws_ssm_client_double || stub_aws_ssm_client(account_id: account_id)
+    request_path = "/#{infrastructure_name}/#{service_name}/#{environment_name}/"
 
     allow(aws_ssm_client)
       .to receive(:get_parameters_by_path)
@@ -32,11 +35,13 @@ module AwsApiHelpers
 
   def stub_call_to_aws_for_infrastructure_variables(
     account_id:,
+    service_name:,
+    environment_name:,
     aws_ssm_client_double: nil,
-    request_path:,
     environment_variables:
   )
     aws_ssm_client = aws_ssm_client_double || stub_aws_ssm_client(account_id: account_id)
+    request_path = "/dalmatian-variables/infrastructures/#{service_name}/#{environment_name}/"
 
     allow(aws_ssm_client)
       .to receive(:get_parameters_by_path)

--- a/spec/support/aws_api_helpers.rb
+++ b/spec/support/aws_api_helpers.rb
@@ -1,4 +1,6 @@
 module AwsApiHelpers
+  CORE_AWS_ACCOUNT_ID = "0011122233344".freeze
+
   def create_aws_environment_variable(name:, value:)
     Aws::SSM::Types::Parameter.new(
       name: name,
@@ -14,14 +16,14 @@ module AwsApiHelpers
   end
 
   def stub_call_to_aws_for_environment_variables(
-    aws_ssm_client_double: nil,
+    aws_ssm_client: nil,
     account_id:,
     infrastructure_name:,
     service_name:,
     environment_name:,
     environment_variables:
   )
-    aws_ssm_client = aws_ssm_client_double || stub_aws_ssm_client(account_id: account_id)
+    aws_ssm_client = aws_ssm_client || stub_aws_ssm_client(account_id: account_id)
     request_path = "/#{infrastructure_name}/#{service_name}/#{environment_name}/"
 
     allow(aws_ssm_client)
@@ -34,13 +36,15 @@ module AwsApiHelpers
   end
 
   def stub_call_to_aws_for_infrastructure_variables(
-    account_id:,
+    aws_ssm_client: nil,
     service_name:,
     environment_name:,
-    aws_ssm_client_double: nil,
     environment_variables:
   )
-    aws_ssm_client = aws_ssm_client_double || stub_aws_ssm_client(account_id: account_id)
+    aws_ssm_client ||= stub_aws_ssm_client(
+      aws_sts_client: stub_main_aws_sts_client,
+      account_id: CORE_AWS_ACCOUNT_ID
+    )
     request_path = "/dalmatian-variables/infrastructures/#{service_name}/#{environment_name}/"
 
     allow(aws_ssm_client)
@@ -53,7 +57,7 @@ module AwsApiHelpers
   end
 
   def stub_call_to_aws_to_update_environment_variables(
-    aws_ssm_client_double: nil,
+    aws_ssm_client: nil,
     account_id:,
     infrastructure_identifier:,
     service_name:,
@@ -61,7 +65,7 @@ module AwsApiHelpers
     variable_name:,
     variable_value:
   )
-    aws_ssm_client = aws_ssm_client_double || stub_aws_ssm_client(account_id: account_id)
+    aws_ssm_client = aws_ssm_client || stub_aws_ssm_client(account_id: account_id)
 
     path = "/#{infrastructure_identifier}/#{service_name}/#{environment_name}/"
     name_with_path = "#{path}#{variable_name}"
@@ -81,14 +85,14 @@ module AwsApiHelpers
   end
 
   def stub_call_to_aws_to_update_infrastructure_variables(
-    aws_ssm_client_double: nil,
+    aws_ssm_client: nil,
     account_id:,
     infrastructure_identifier:,
     environment_name:,
     variable_name:,
     variable_value:
   )
-    aws_ssm_client = aws_ssm_client_double || stub_aws_ssm_client(account_id: account_id)
+    aws_ssm_client = aws_ssm_client || stub_aws_ssm_client(account_id: account_id)
 
     path = "/dalmatian-variables/infrastructures/#{infrastructure_identifier}/#{environment_name}/"
     name_with_path = "#{path}#{variable_name}"
@@ -108,7 +112,7 @@ module AwsApiHelpers
   end
 
   def stub_call_to_aws_to_delete_environment_variable(
-    aws_ssm_client_double: nil,
+    aws_ssm_client: nil,
     account_id:,
     infrastructure_name:,
     service_name:,
@@ -116,7 +120,7 @@ module AwsApiHelpers
     variable_name:
   )
 
-    aws_ssm_client = aws_ssm_client_double || stub_aws_ssm_client(account_id: account_id)
+    aws_ssm_client = aws_ssm_client || stub_aws_ssm_client(account_id: account_id)
     full_name = "#{infrastructure_name}/#{service_name}/#{environment_name}/#{variable_name}"
 
     allow(aws_ssm_client)
@@ -125,14 +129,14 @@ module AwsApiHelpers
   end
 
   def stub_call_to_aws_to_delete_infrastructure_variable(
-    aws_ssm_client_double: nil,
+    aws_ssm_client: nil,
     account_id:,
     service_name:,
     environment_name:,
     variable_name:
   )
 
-    aws_ssm_client = aws_ssm_client_double || stub_aws_ssm_client(account_id: account_id)
+    aws_ssm_client = aws_ssm_client || stub_aws_ssm_client(account_id: account_id)
     full_name = "/dalmatian-variables/infrastructures/#{service_name}/#{environment_name}/#{variable_name}"
 
     allow(aws_ssm_client)
@@ -140,7 +144,7 @@ module AwsApiHelpers
       .with(name: full_name)
   end
 
-  def stub_aws_ssm_client(account_id:)
+  def stub_aws_ssm_client(aws_sts_client: stub_aws_sts_client, account_id:)
     credentials = instance_double(Aws::AssumeRoleCredentials)
     allow(Aws::AssumeRoleCredentials).to receive(:new).with(
       client: aws_sts_client,
@@ -148,18 +152,27 @@ module AwsApiHelpers
       role_session_name: "role_session_name"
     ).and_return(credentials)
 
-    aws_ssm_client_double = instance_double(Aws::SSM::Client)
+    aws_ssm_client = instance_double(Aws::SSM::Client)
     allow(Aws::SSM::Client)
       .to receive(:new)
       .with(credentials: credentials)
-      .and_return(aws_ssm_client_double)
+      .and_return(aws_ssm_client)
 
-    aws_ssm_client_double
+    aws_ssm_client
+  end
+
+  def stub_main_aws_sts_client
+    aws_sts_client = instance_double(Aws::STS::Client)
+    allow(Aws::STS::Client).to receive(:new).and_return(aws_sts_client)
+    allow(aws_sts_client)
+      .to receive_message_chain(:get_caller_identity, :account)
+      .and_return(CORE_AWS_ACCOUNT_ID)
+    aws_sts_client
   end
 
   private
 
-  def aws_sts_client
+  def stub_aws_sts_client
     aws_sts_client = instance_double(Aws::STS::Client)
     allow(Aws::STS::Client).to receive(:new).and_return(aws_sts_client)
     aws_sts_client

--- a/spec/support/aws_api_helpers.rb
+++ b/spec/support/aws_api_helpers.rb
@@ -110,13 +110,15 @@ module AwsApiHelpers
   def stub_call_to_aws_to_delete_environment_variable(
     aws_ssm_client_double: nil,
     account_id:,
-    request_path:,
-    name:
+    infrastructure_name:,
+    service_name:,
+    environment_name:,
+    variable_name:
   )
 
     aws_ssm_client = aws_ssm_client_double || stub_aws_ssm_client(account_id: account_id)
+    full_name = "#{infrastructure_name}/#{service_name}/#{environment_name}/#{variable_name}"
 
-    full_name = "#{request_path}/#{name}"
     allow(aws_ssm_client)
       .to receive(:delete_parameter)
       .with(name: full_name)
@@ -125,13 +127,14 @@ module AwsApiHelpers
   def stub_call_to_aws_to_delete_infrastructure_variable(
     aws_ssm_client_double: nil,
     account_id:,
-    request_path:,
-    name:
+    service_name:,
+    environment_name:,
+    variable_name:
   )
 
     aws_ssm_client = aws_ssm_client_double || stub_aws_ssm_client(account_id: account_id)
+    full_name = "/dalmatian-variables/infrastructures/#{service_name}/#{environment_name}/#{variable_name}"
 
-    full_name = "#{request_path}/#{name}"
     allow(aws_ssm_client)
       .to receive(:delete_parameter)
       .with(name: full_name)

--- a/spec/support/aws_api_helpers.rb
+++ b/spec/support/aws_api_helpers.rb
@@ -30,6 +30,23 @@ module AwsApiHelpers
       ).and_return(environment_variables)
   end
 
+  def stub_call_to_aws_for_infrastructure_variables(
+    account_id:,
+    aws_ssm_client_double: nil,
+    request_path:,
+    environment_variables:
+  )
+    aws_ssm_client = aws_ssm_client_double || stub_aws_ssm_client(account_id: account_id)
+
+    allow(aws_ssm_client)
+      .to receive(:get_parameters_by_path)
+      .with(
+        path: request_path,
+        with_decryption: true,
+        recursive: false
+      ).and_return(environment_variables)
+  end
+
   def stub_call_to_aws_to_update_environment_variables(
     aws_ssm_client_double: nil,
     account_id:,

--- a/spec/support/aws_api_helpers.rb
+++ b/spec/support/aws_api_helpers.rb
@@ -23,7 +23,7 @@ module AwsApiHelpers
     environment_name:,
     environment_variables:
   )
-    aws_ssm_client = aws_ssm_client || stub_aws_ssm_client(account_id: account_id)
+    aws_ssm_client ||= stub_aws_ssm_client(account_id: account_id)
     request_path = "/#{infrastructure_name}/#{service_name}/#{environment_name}/"
 
     allow(aws_ssm_client)
@@ -65,7 +65,7 @@ module AwsApiHelpers
     variable_name:,
     variable_value:
   )
-    aws_ssm_client = aws_ssm_client || stub_aws_ssm_client(account_id: account_id)
+    aws_ssm_client ||= stub_aws_ssm_client(account_id: account_id)
 
     path = "/#{infrastructure_identifier}/#{service_name}/#{environment_name}/"
     name_with_path = "#{path}#{variable_name}"
@@ -92,7 +92,7 @@ module AwsApiHelpers
     variable_name:,
     variable_value:
   )
-    aws_ssm_client = aws_ssm_client || stub_aws_ssm_client(account_id: account_id)
+    aws_ssm_client ||= stub_aws_ssm_client(account_id: account_id)
 
     path = "/dalmatian-variables/infrastructures/#{infrastructure_identifier}/#{environment_name}/"
     name_with_path = "#{path}#{variable_name}"
@@ -120,7 +120,7 @@ module AwsApiHelpers
     variable_name:
   )
 
-    aws_ssm_client = aws_ssm_client || stub_aws_ssm_client(account_id: account_id)
+    aws_ssm_client ||= stub_aws_ssm_client(account_id: account_id)
     full_name = "#{infrastructure_name}/#{service_name}/#{environment_name}/#{variable_name}"
 
     allow(aws_ssm_client)
@@ -136,7 +136,7 @@ module AwsApiHelpers
     variable_name:
   )
 
-    aws_ssm_client = aws_ssm_client || stub_aws_ssm_client(account_id: account_id)
+    aws_ssm_client ||= stub_aws_ssm_client(account_id: account_id)
     full_name = "/dalmatian-variables/infrastructures/#{service_name}/#{environment_name}/#{variable_name}"
 
     allow(aws_ssm_client)


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

- a series of refactorings to refine existing testing of AWS API interactions to make the fix easier to apply. A large refactor was a change to passing in an `aws_sms_client` rather than only an `infrastructure` into the AWS services. This makes it possible to pass in a second type of client for the cases where the variables are not living on the same AWS account that the service is running in
- infrastructure variables now show up, are added to, and deleted from the central AWS account
