### PR TITLE
Fix/remove turbolinks so toggling secrets works reliably

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,6 @@ gem "rollbar"
 gem "rails", "~> 6.0.0"
 gem "sass-rails", "~> 6.0"
 gem "simple_form"
-gem "turbolinks", "~> 5"
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
 gem "uglifier", ">= 1.3.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -314,9 +314,6 @@ GEM
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    turbolinks (5.2.1)
-      turbolinks-source (~> 5.2)
-    turbolinks-source (5.2.0)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     uglifier (4.2.0)
@@ -379,7 +376,6 @@ DEPENDENCIES
   spring-commands-rspec
   spring-watcher-listen (~> 2.0.0)
   standard
-  turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,6 +13,5 @@
 //= require jquery3
 //= require popper
 //= require rails-ujs
-//= require turbolinks
 //= require bootstrap-sprockets
 //= require_tree .

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -4,8 +4,8 @@
     %meta{:name => "viewport", :content => "width=device-width, initial-scale=1.0"}
     %title= content_for?(:title) ? yield(:title) : I18n.t("app.name")
     %meta{:name => "description", :content => "#{content_for?(:description) ? yield(:description) : 'Rails Template'}"}
-    = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track' => 'reload'
-    = javascript_include_tag 'application', 'data-turbolinks-track' => 'reload'
+    = stylesheet_link_tag 'application', media: 'all'
+    = javascript_include_tag 'application'
     = csrf_meta_tags
   %body
     %header


### PR DESCRIPTION
- Turbolinks gem removed
- We can write conventional Javascript without having to worry about making it work with Turbolinks
- Switching variable tabs and toggling secrets now works without requiring a full page reload