### PR TITLE
Users can download all environment variables in a .env file

### DIFF
--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -7,7 +7,7 @@ class DownloadsController < ApplicationController
     environment_variables = all_environment_variables[service_name][environment_name]
 
     filename = "dalmatian_#{service_name}_#{environment_name}_#{Time.now.utc.to_i}.env"
-    file_path = "./tmp/#{filename}"
+    file_path = "./tmp/downloads/#{filename}"
     File.atomic_write(file_path) do |file|
       environment_variables.each do |variable|
         file.write("#{variable.name}=#{variable.value}\n")

--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class DownloadsController < ApplicationController
+  def new
+    @infrastructure = Infrastructure.find(infrastructure_id)
+    all_environment_variables = FindEnvironmentVariables.new(infrastructure: @infrastructure).call
+    environment_variables = all_environment_variables[service_name][environment_name]
+
+    filename = "dalmatian_#{service_name}_#{environment_name}_#{Time.now.utc.to_i}.env"
+    file_path = "./tmp/#{filename}"
+    File.atomic_write(file_path) do |file|
+      environment_variables.each do |variable|
+        file.write("#{variable.name}=#{variable.value}\n")
+      end
+    end
+
+    send_file(
+      file_path,
+      filename: filename,
+      type: "application/env"
+    )
+  end
+
+  private
+
+  def infrastructure_id
+    params[:infrastructure_id]
+  end
+
+  def service_name
+    params["service_name"]
+  end
+
+  def environment_name
+    params["environment_name"]
+  end
+end

--- a/app/views/environment_variables/index.html.erb
+++ b/app/views/environment_variables/index.html.erb
@@ -12,6 +12,7 @@
       </h3>
       <%= link_to I18n.t("button.add_or_update_variable"), new_infrastructure_environment_variable_path(@infrastructure, service_name: service_name, environment_name: environment_name), class: "btn btn-success mb-4" %>
       <%= link_to I18n.t("button.upload_env_file"), new_infrastructure_env_file_path(@infrastructure, service_name: service_name, environment_name: environment_name), class: "btn btn-primary mb-4" %>
+      <%= link_to I18n.t("button.download_environment_variables"), new_infrastructure_download_path(@infrastructure, service_name: service_name, environment_name: environment_name), class: "btn btn-primary mb-4" %>
       <%= render 'environment_variable_table', infrastructure: @infrastructure, environment_variables: environment_variables, service_name: service_name, environment_name: environment_name %>
     <% end %>
   <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,6 +18,10 @@ Bundler.require(*Rails.groups)
 
 module DalmatianFrontend
   class Application < Rails::Application
+    # Remove environment variable downloads from any previous session
+    FileUtils.remove_dir("tmp/downloads") if Dir.exist?("tmp/downloads")
+    Dir.mkdir("tmp/downloads")
+
     config.autoload_paths += %W[#{config.root}/lib]
 
     config.mongoid.logger.level = Logger::WARN

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,8 +12,8 @@ en:
       new: "Upload multiple environment variables"
   button:
     add_or_update_variable: "Create or update variable"
+    download_environment_variables: Download
     delete: "Delete"
-    upload_env_file: "Upload multiple variables"
     upload_env_file: "Upload"
     apply: "Apply"
     continue: "Continue"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -14,6 +14,7 @@ en:
     add_or_update_variable: "Create or update variable"
     delete: "Delete"
     upload_env_file: "Upload multiple variables"
+    upload_env_file: "Upload"
     apply: "Apply"
     continue: "Continue"
   tab:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   resources :infrastructures, only: [:show, :index] do
     resources :environment_variables, only: [:new, :create, :destroy, :index] do
       collection do
+        resources :downloads, only: [:new]
         resources :env_files, only: [:new, :create] do
           collection do
             post "confirm", to: "env_files#confirm"

--- a/spec/features/users_can_download_all_environment_variables_spec.rb
+++ b/spec/features/users_can_download_all_environment_variables_spec.rb
@@ -1,0 +1,31 @@
+feature "Users can download environment variables" do
+  scenario "lists out the keys and values" do
+    infrastructure = Infrastructure.create(
+      identifier: "test-app",
+      account_id: "345",
+      services: [{"name" => "test-service"}],
+      environments: {"staging" => []}
+    )
+
+    fake_environment_variables = Aws::SSM::Types::GetParametersByPathResult.new(parameters: [
+      create_aws_environment_variable(name: "FOO", value: "BAR"),
+      create_aws_environment_variable(name: "DATABASE_URL", value: "BAZ")
+    ])
+
+    stub_call_to_aws_for_environment_variables(
+      account_id: infrastructure.account_id,
+      infrastructure_name: infrastructure.identifier,
+      service_name: "test-service",
+      environment_name: "staging",
+      environment_variables: fake_environment_variables
+    )
+
+    visit infrastructure_path(infrastructure)
+
+    click_on(I18n.t("tab.environment_variables"))
+    click_on(I18n.t("button.download_environment_variables"))
+
+    expect(page).to have_content("FOO=BAR")
+    expect(page).to have_content("DATABASE_URL=BAZ")
+  end
+end


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

Users can download all environment variables for any singular _environment_ as a .env file. 

This file can then be used to upload back to the same or different environment to make multiple changes or set up multiple environments at once.

The tmp files created are tidied up at the start of a new server session to reduce the risk of secrets lying around in a hidden directory.

## Screenshots of UI changes

![Screenshot 2020-09-29 at 14 56 23](https://user-images.githubusercontent.com/912473/94568516-7e119a00-0264-11eb-947b-7ba6f8f08bf2.png)
![Screenshot 2020-09-29 at 14 56 44](https://user-images.githubusercontent.com/912473/94568523-7fdb5d80-0264-11eb-9433-ece76fc0718f.png)
