### PR TITLE
Chore/pages respond to smaller windows

### DIFF
--- a/app/views/env_files/confirm.html.erb
+++ b/app/views/env_files/confirm.html.erb
@@ -1,5 +1,7 @@
-  <h3 class="mt-5"><%= I18n.t("page_title.env_files.confirm") %></h3>
 <div class="col-lg-10 offset-lg-1 col-md-10 offset-md-1 col-sm-12">
+  <%= render "shared/breadcrumbs", locals: { infrastructure: @infrastructure, service_name: service_name, environment_name: environment_name } %>
+
+  <h3><%= I18n.t("page_title.env_files.confirm") %></h3>
 
   <dl class="row">
     <% @env_file.contents.each_pair do |key, value| %>

--- a/app/views/env_files/confirm.html.erb
+++ b/app/views/env_files/confirm.html.erb
@@ -1,5 +1,5 @@
-<div class="col-8 offset-2">
   <h3 class="mt-5"><%= I18n.t("page_title.env_files.confirm") %></h3>
+<div class="col-lg-10 offset-lg-1 col-md-10 offset-md-1 col-sm-12">
 
   <dl class="row">
     <% @env_file.contents.each_pair do |key, value| %>

--- a/app/views/env_files/new.html.erb
+++ b/app/views/env_files/new.html.erb
@@ -1,5 +1,5 @@
-<div class="col-8 offset-2">
   <h3 class="mt-5"><%= I18n.t("page_title.env_files.new") %></h3>
+<div class="col-lg-6 offset-lg-3 col-md-10 offset-md-1 col-sm-12">
   <p>Provide a file with the following:</p>
   <ul>
     <li>.env format</li>

--- a/app/views/env_files/new.html.erb
+++ b/app/views/env_files/new.html.erb
@@ -1,5 +1,7 @@
-  <h3 class="mt-5"><%= I18n.t("page_title.env_files.new") %></h3>
 <div class="col-lg-6 offset-lg-3 col-md-10 offset-md-1 col-sm-12">
+  <%= render "shared/breadcrumbs", locals: { infrastructure: @infrastructure, service_name: service_name, environment_name: environment_name } %>
+
+  <h3><%= I18n.t("page_title.env_files.new") %></h3>
   <p>Provide a file with the following:</p>
   <ul>
     <li>.env format</li>

--- a/app/views/environment_variables/new.html.erb
+++ b/app/views/environment_variables/new.html.erb
@@ -1,5 +1,7 @@
-  <h1 class="mt-5"><%= I18n.t("page_title.environment_variable.new") %></h1>
 <div class="col-lg-6 offset-lg-3 col-md-10 offset-md-1 col-sm-12">
+  <%= render "shared/breadcrumbs", locals: { infrastructure: @infrastructure, service_name: service_name, environment_name: environment_name } %>
+
+  <h1><%= I18n.t("page_title.environment_variable.new") %></h1>
 
   <p>If you provide an existing variable name this will update the existing value. It is case sensitive.</p>
   <%= simple_form_for(@environment_variable, as: :environment_variable, method: :post, url: infrastructure_environment_variables_path(@infrastructure, service_name: service_name, environment_name: environment_name)) do |f| %>

--- a/app/views/environment_variables/new.html.erb
+++ b/app/views/environment_variables/new.html.erb
@@ -1,5 +1,5 @@
-<div class="col-4 offset-4">
   <h1 class="mt-5"><%= I18n.t("page_title.environment_variable.new") %></h1>
+<div class="col-lg-6 offset-lg-3 col-md-10 offset-md-1 col-sm-12">
 
   <p>If you provide an existing variable name this will update the existing value. It is case sensitive.</p>
   <%= simple_form_for(@environment_variable, as: :environment_variable, method: :post, url: infrastructure_environment_variables_path(@infrastructure, service_name: service_name, environment_name: environment_name)) do |f| %>

--- a/app/views/infrastructure_variables/index.html.erb
+++ b/app/views/infrastructure_variables/index.html.erb
@@ -8,7 +8,7 @@
       <%= environment_name %>
       <small class="text-muted">environment</small>
     </h3>
-    <%= link_to I18n.t("button.add_or_update_variable"), new_infrastructure_variable_path(@infrastructure, environment_name: environment_name), class: "btn btn-primary mb-4" %>
+    <%= link_to I18n.t("button.add_or_update_variable"), new_infrastructure_variable_path(@infrastructure, environment_name: environment_name), class: "btn btn-success mb-4" %>
 
     <%= render "environment_variable_table", infrastructure: @infrastructure, infrastructure_variables: infrastructure_variables, environment_name: environment_name %>
   <% end %>

--- a/app/views/infrastructure_variables/new.html.erb
+++ b/app/views/infrastructure_variables/new.html.erb
@@ -1,7 +1,7 @@
-<div class="col-4 offset-4">
   <h1 class="mt-5">
     <%= I18n.t("page_title.infrastructure_variable.new") %>
   </h1>
+<div class="col-lg-6 offset-lg-3 col-md-10 offset-md-1 col-sm-12">
 
   <p>If you provide an existing variable name this will update the existing value. It is case sensitive.</p>
   <%= simple_form_for(@infrastructure_variable, as: :infrastructure_variable, method: :post, url: infrastructure_variables_path(@infrastructure, environment_name: environment_name)) do |f| %>

--- a/app/views/infrastructure_variables/new.html.erb
+++ b/app/views/infrastructure_variables/new.html.erb
@@ -1,7 +1,7 @@
-  <h1 class="mt-5">
-    <%= I18n.t("page_title.infrastructure_variable.new") %>
-  </h1>
 <div class="col-lg-6 offset-lg-3 col-md-10 offset-md-1 col-sm-12">
+  <%= render "shared/breadcrumbs", locals: { infrastructure: @infrastructure, environment_name: environment_name } %>
+
+  <h1><%= I18n.t("page_title.infrastructure_variable.new") %></h1>
 
   <p>If you provide an existing variable name this will update the existing value. It is case sensitive.</p>
   <%= simple_form_for(@infrastructure_variable, as: :infrastructure_variable, method: :post, url: infrastructure_variables_path(@infrastructure, environment_name: environment_name)) do |f| %>

--- a/app/views/infrastructures/index.html.erb
+++ b/app/views/infrastructures/index.html.erb
@@ -1,4 +1,4 @@
-<div class="col-6 offset-3">
+<div class="col-lg-4 offset-lg-4 col-md-8 offset-md-2 col-sm-12">
   <h1 class="mt-4 mb-4"><%= I18n.t("page_title.infrastructures") %></h1>
 
   <div class="alert alert-warning" role="alert">

--- a/app/views/shared/_breadcrumbs.html.erb
+++ b/app/views/shared/_breadcrumbs.html.erb
@@ -1,0 +1,11 @@
+<nav aria-label="breadcrumb" class="mt-5">
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item">
+      <%= link_to locals[:infrastructure].identifier, infrastructure_environment_variables_path(locals[:infrastructure]) %>
+    </li>
+    <% if locals.key?(:service_name) %>
+      <li class="breadcrumb-item"><%= service_name %></li>
+    <% end %>
+    <li class="breadcrumb-item active" aria-current="page"><%= environment_name %></li>
+  </ol>
+</nav>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,9 +12,9 @@ en:
       new: "Upload multiple environment variables"
   button:
     add_or_update_variable: "Create or update variable"
-    download_environment_variables: Download
+    download_environment_variables: Download ENV
     delete: "Delete"
-    upload_env_file: "Upload"
+    upload_env_file: "Upload ENV"
     apply: "Apply"
     continue: "Continue"
   tab:


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

Pages are more responsive. Smaller browser windows will cause the content to use more of the page, rather than appear squished. Only larger windows will keep content centralised to the middle of the page.

Add breadcrumbs into new and uploads pages to help remind users where they are and in what context their action is being applied.

## Screenshots of UI changes

![Screenshot 2020-09-29 at 15 48 08](https://user-images.githubusercontent.com/912473/94574574-317d8d00-026b-11eb-91c8-68e04430d34c.png)
![Screenshot 2020-09-29 at 15 47 58](https://user-images.githubusercontent.com/912473/94574577-32aeba00-026b-11eb-9dfb-bfc345a993aa.png)
