### PR TITLE
Feature/users can execute a new build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - infrastructure variables are shown for every infrastructure (not just those running on the core AWS account)
 - multiple environment variables can be added at once with a .env file
 - users can see build information in the form of AWS CodePipelines
+- users can execute new code pipeline runs to deploy apps
 
 [unreleased]: TODO
 [keep a changelog 1.0.0]: https://keepachangelog.com/en/1.0.0/

--- a/app/controllers/builds_controller.rb
+++ b/app/controllers/builds_controller.rb
@@ -2,15 +2,33 @@
 
 class BuildsController < ApplicationController
   include AwsClientWrapper
+
   def index
     @infrastructure = Infrastructure.find(infrastructure_id)
     pipeline_states = FindBuildPipelines.new(infrastructure: @infrastructure).call
     @pipelines = pipeline_states.map { |state| PipelinePresenter.new(state) }
   end
 
+  def new
+    @infrastructure = Infrastructure.find(infrastructure_id)
+
+    result = ExecuteCodePipeline.new(infrastructure: @infrastructure)
+      .call(pipeline_name: pipeline_name)
+
+    flash_message = {}
+    flash_message[:notice] = "CodePipeline '#{pipeline_name}' has been executed" if result.success?
+    flash_message[:error] = "CodePipeline '#{pipeline_name}' failed because #{result.error_message}" if result.failure?
+
+    redirect_to infrastructure_builds_path(@infrastructure), flash: flash_message
+  end
+
   private
 
   def infrastructure_id
     params[:infrastructure_id]
+  end
+
+  def pipeline_name
+    params[:pipeline]
   end
 end

--- a/app/controllers/environment_variables_controller.rb
+++ b/app/controllers/environment_variables_controller.rb
@@ -16,7 +16,10 @@ class EnvironmentVariablesController < ApplicationController
         infrastructure: @infrastructure,
         environment_variable: @environment_variable
       ).call
-      redirect_to infrastructure_environment_variables_path(@infrastructure)
+      flash_message = {}
+      flash_message[:notice] = "This variable was successfully set"
+      flash_message[:danger] = "To apply this change to the service you will need to execute a new deployment from the builds tab"
+      redirect_to infrastructure_environment_variables_path(@infrastructure), flash: flash_message
     else
       render :new
     end

--- a/app/controllers/infrastructure_variables_controller.rb
+++ b/app/controllers/infrastructure_variables_controller.rb
@@ -16,7 +16,10 @@ class InfrastructureVariablesController < ApplicationController
         infrastructure: @infrastructure,
         infrastructure_variable: @infrastructure_variable
       ).call
-      redirect_to infrastructure_variables_path(@infrastructure)
+      flash_message = {}
+      flash_message[:notice] = "This variable was successfully set"
+      flash_message[:danger] = "To apply this change to the service you will need to execute a new deployment from the builds tab"
+      redirect_to infrastructure_variables_path(@infrastructure), flash: flash_message
     else
       render :new
     end

--- a/app/services/execute_code_pipeline.rb
+++ b/app/services/execute_code_pipeline.rb
@@ -1,0 +1,25 @@
+class ExecuteCodePipeline
+  include AwsClientWrapper
+
+  attr_accessor :infrastructure
+
+  def initialize(infrastructure:)
+    self.infrastructure = infrastructure
+  end
+
+  def call(pipeline_name:)
+    begin
+      client.start_pipeline_execution(name: pipeline_name)
+      result = Result.new(true)
+    rescue Aws::CodePipeline::Errors::PipelineNotFoundException => error
+      result = Result.new(false, error, error.message)
+    end
+    result
+  end
+
+  private
+
+  def client
+    @client ||= CodePipeline.new(infrastructure: @infrastructure).call
+  end
+end

--- a/app/views/builds/index.html.erb
+++ b/app/views/builds/index.html.erb
@@ -4,9 +4,9 @@
 
 <div class="col-12 col-md-12 pt-4">
   <% @pipelines.each do |pipeline| %>
-    <h2 class="mt-4 mb-4"><%= pipeline.name %></h2>
-
-    <div class="row">
+    <h2 class="mb-4"><%= pipeline.name %></h2>
+    <%= link_to I18n.t("button.execute"), new_infrastructure_build_path(@infrastructure, pipeline: pipeline.name), class: "btn btn-success" %>
+    <div class="row mt-4">
       <% pipeline.stages.each do |stage| %>
         <div class="col-sm-12 col-md-6 col-lg-4">
           <div class="card mb-4 stage-<%= stage.name.downcase %>">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,6 +20,7 @@ en:
     upload_env_file: "Upload ENV"
     apply: "Apply"
     continue: "Continue"
+    execute: "Execute"
   tab:
     configuration: "Configuration"
     environment_variables: "Environment variables"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,6 @@ Rails.application.routes.draw do
       end
     end
     resources :infrastructure_variables, only: [:new, :create, :destroy, :index], as: :variables
-    resources :builds, only: [:index]
+    resources :builds, only: [:index, :new]
   end
 end

--- a/spec/features/users_can_add_a_new_environment_variable_spec.rb
+++ b/spec/features/users_can_add_a_new_environment_variable_spec.rb
@@ -57,6 +57,8 @@ feature "Users can add new environment variables" do
 
     expect(page).to have_content("FOO")
     expect(page).to have_content("BAAZ")
+    expect(page).to have_content("This variable was successfully set")
+    expect(page).to have_content("To apply this change to the service you will need to execute a new deployment from the builds tab")
   end
 
   scenario "updates an existing variable" do

--- a/spec/features/users_can_add_a_new_infrastructure_variable_spec.rb
+++ b/spec/features/users_can_add_a_new_infrastructure_variable_spec.rb
@@ -56,6 +56,8 @@ feature "Users can add new infrastructure variables" do
 
     expect(page).to have_content("FOO")
     expect(page).to have_content("BAAZ")
+    expect(page).to have_content("This variable was successfully set")
+    expect(page).to have_content("To apply this change to the service you will need to execute a new deployment from the builds tab")
   end
 
   scenario "updates an existing variable" do

--- a/spec/features/users_can_initiate_a_new_deploy_spec.rb
+++ b/spec/features/users_can_initiate_a_new_deploy_spec.rb
@@ -1,0 +1,73 @@
+feature "Users can start a deployment" do
+  let(:infrastructure) { Infrastructure.create(identifier: "test-app", account_id: "345") }
+  let(:aws_code_pipeline_client) { stub_aws_code_pipeline_client(account_id: infrastructure.account_id) }
+
+  scenario "User can execute a code pipeline to start" do
+    stub_pipeline
+
+    allow(aws_code_pipeline_client).to receive(:start_pipeline_execution).and_return(
+      Aws::CodePipeline::Types::StartPipelineExecutionOutput.new(
+        pipeline_execution_id: "123"
+      )
+    )
+    visit infrastructure_builds_path(infrastructure)
+
+    click_on(I18n.t("button.execute"))
+
+    expect(page).to have_content("CodePipeline 'test-app-pipeline' has been executed")
+  end
+
+  scenario "User are told when an execution fails" do
+    stub_pipeline
+
+    allow(aws_code_pipeline_client).to receive(:start_pipeline_execution).and_raise(
+      Aws::CodePipeline::Errors::PipelineNotFoundException.new(
+        anything,
+        "The account with id '123123123' does not include a pipeline with the name 'pipeline-name'"
+      )
+    )
+
+    visit infrastructure_builds_path(infrastructure)
+
+    click_on(I18n.t("button.execute"))
+
+    expect(page).to have_content(
+      "CodePipeline 'test-app-pipeline' failed because The account with id '123123123' does not include a pipeline with the name 'pipeline-name'"
+    )
+  end
+
+  def stub_pipeline
+    allow(aws_code_pipeline_client).to receive(:list_pipelines)
+      .and_return(Aws::CodePipeline::Types::ListPipelinesOutput.new(
+        pipelines: [
+          Aws::CodePipeline::Types::PipelineSummary.new(
+            name: "test-app-pipeline"
+          )
+        ]
+      ))
+
+    fake_pipeline_state = Aws::CodePipeline::Types::GetPipelineStateOutput.new(
+      pipeline_name: "test-app-pipeline",
+      stage_states: [
+        Aws::CodePipeline::Types::StageState.new(
+          stage_name: "Source",
+          action_states: [
+            Aws::CodePipeline::Types::ActionState.new(
+              action_name: "Source",
+              latest_execution: Aws::CodePipeline::Types::ActionExecution.new(
+                status: "Succeeded",
+                summary: "Merge pull request #32 from dxw",
+                last_status_change: Time.new(2019, 7, 3, 16, 9, 4, "+01:00"),
+                external_execution_url: nil
+              )
+            )
+          ]
+        )
+      ]
+    )
+
+    allow(aws_code_pipeline_client).to receive(:get_pipeline_state)
+      .with(name: "test-app-pipeline")
+      .and_return(fake_pipeline_state)
+  end
+end


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

- any code pipeline can now be executed causing all stages to be re-run
- after adding environment or infrastructure variables the service steers the user into deployment to finish the journey (we can automate this step later if we want to)

## Screenshots of UI changes

![Screenshot 2020-10-02 at 17 14 02](https://user-images.githubusercontent.com/912473/94945540-bc13f580-04d2-11eb-9a84-ad4a87dab071.png)
![Screenshot 2020-10-02 at 17 14 08](https://user-images.githubusercontent.com/912473/94945542-bd452280-04d2-11eb-8eb1-e9169e384edb.png)
![Screenshot 2020-10-02 at 17 14 16](https://user-images.githubusercontent.com/912473/94945549-be764f80-04d2-11eb-8492-d09d77b31494.png)
![Screenshot 2020-10-02 at 17 13 55](https://user-images.githubusercontent.com/912473/94945880-40ff0f00-04d3-11eb-9eaf-bfefe01d7a63.png)
