### PR TITLE
Only set the bundle path for this app

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -53,7 +53,7 @@ if [ -z "$CI" ]; then
 
   if ! bundle check >/dev/null 2>&1; then
     echo "==> Installing Ruby dependencies..."
-    bundle config set path vendor/bundle
+    bundle config set --local path vendor/bundle
     bundle install
   fi
 


### PR DESCRIPTION
To save space people can configure bundler to use a shared path for all bundle
installs. This can also make installing gems for new apps quicker since they
may already exist.

Do not override people's bundler settings globally only override the local
bundler configuration
