### PR TITLE
`docker-compose` robustness

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -18,7 +18,7 @@ services:
       - mongodb
     command: /bin/sh -c "./script/test"
     volumes:
-      - ./coverage:/srv/app/coverage
+      - .:/srv/app
 
   mongodb:
     image: mongo:4.4


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

- Mount the entire repository at /srv/app inside the container
- Precompile assets on run, not when building the image
- Do not copy the repository into the image
- Add bundle install to docker-entrypoint.sh

## Screenshots of UI changes

N/A

## Next steps

N/A