### PR TITLE
Users can see how to connect to each RDS database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - users can execute a new pipeline run for Dalmatian Core
 - DALMATIAN_AWS_ACCOUNT_ID automatically set on server start if absent
 - DALMATIAN_CI_PIPELINE automatically set on server start if absent
+- users can see how to connect directly to each RDS instance
 
 [unreleased]: TODO
 [keep a changelog 1.0.0]: https://keepachangelog.com/en/1.0.0/

--- a/app/controllers/databases_controller.rb
+++ b/app/controllers/databases_controller.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class DatabasesController < ApplicationController
+  include AwsClientWrapper
+
+  def index
+    @infrastructure = Infrastructure.find(infrastructure_id)
+
+    @databases = @infrastructure.rds.map { |rds|
+      OpenStruct.new(
+        identifier: rds["identifier"],
+        name: rds["db_name"],
+        engine: rds["engine"],
+        engine_version: rds["engine_version"],
+        instance_class: rds["instance_class"]
+      )
+    }
+  end
+
+  private
+
+  def infrastructure_id
+    params[:infrastructure_id]
+  end
+end

--- a/app/views/databases/index.html.erb
+++ b/app/views/databases/index.html.erb
@@ -1,0 +1,36 @@
+<h1 class="mt-4 mb-4"><%= @infrastructure.identifier %></h1>
+
+<%= render "shared/tabs", locals: { infrastructure: @infrastructure } %>
+
+<div class="col-6 col-md-6 pt-4">
+  <h3>Information</h3>
+  <% @databases.each do |rds| %>
+    <dl>
+      <h2 class="mb-4"></h2>
+        <dt>Identifier</dt>
+        <dd><%= rds.identifier %></dd>
+        <dt>Name</dt>
+        <dd><%= rds.name %></dd>
+        <dt>Engine</dt>
+        <dd><%= rds.engine %></dd>
+        <dt>Engine version</dt>
+        <dd><%= rds.engine_version %></dd>
+        <dt>Instance class</dt>
+        <dd><%= rds.instance_class %></dd>
+    </dl>
+
+    <h3>Connect to this instance</h3>
+    <ol id="connect-steps">
+      <li><a href="https://github.com/dxw/dalmatian-tools/"><%= I18n.t("database.connect.step.1") %></a></li>
+      <li><a href="https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html#install-plugin-macos"><%= I18n.t("database.connect.step.2") %></a></li>
+      <li><%= I18n.t("database.connect.step.3") %></li>
+    </ol
+
+    <% @infrastructure.environment_names.each do |environment_name| %>
+      <h4><%= environment_name.capitalize %></h4>
+      <pre id="<%= environment_name %>-snippet"><code>
+        <%= "dalmatian rds shell -i #{@infrastructure.identifier} -e #{environment_name} -r #{rds.identifier}" %>
+      </code></pre>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/shared/_tabs.html.erb
+++ b/app/views/shared/_tabs.html.erb
@@ -11,4 +11,7 @@
   <li class="nav-item">
     <%= link_to I18n.t("tab.logs"), infrastructure_builds_path(@infrastructure), class: "nav-link #{active_link(path: infrastructure_builds_path(@infrastructure))}" %>
   </li>
+  <li class="nav-item">
+    <%= link_to I18n.t("tab.databases"), infrastructure_databases_path(@infrastructure), class: "nav-link #{active_link(path: infrastructure_databases_path(@infrastructure))}" %>
+  </li>
 </ul>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,8 +26,15 @@ en:
     environment_variables: "Environment variables"
     infrastructure_variables: "Infrastructure variables"
     logs: "Builds"
+    databases: "Databases"
   alerts:
     introduction_warning:
       short: "Use with caution."
       long: "This tool authenticates with your machines real AWS credentials. Despite being run locally, any action performed here will make real requests to AWS which may affect live services."
   obfuscation: "************************************"
+  database:
+    connect:
+      step:
+        1: "Install Dalmatian Tools on your machine"
+        2: "Install AWS Session Manager on your machine"
+        3: "Copy and paste the below command into your terminal to connect directly to that RDS instance"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,5 +18,6 @@ Rails.application.routes.draw do
     end
     resources :infrastructure_variables, only: [:new, :create, :destroy, :index], as: :variables
     resources :builds, only: [:index, :new]
+    resources :databases, only: [:index]
   end
 end

--- a/spec/features/users_can_see_database_information_spec.rb
+++ b/spec/features/users_can_see_database_information_spec.rb
@@ -1,0 +1,58 @@
+feature "Users can see environment variables" do
+  scenario "lists out the keys and values" do
+    infrastructure = Infrastructure.create(
+      identifier: "test-app",
+      account_id: "345",
+      services: [{"name" => "test-service"}],
+      environments: {"staging" => [], "production" => []},
+      rds: [
+        {
+          "identifier" => "bikeshed",
+          "instance_class" => "db.t2.small",
+          "engine" => "mysql",
+          "engine_version" => "5.7.26",
+          "db_name" => "bikeshed"
+        }
+      ]
+    )
+
+    visit infrastructure_path(infrastructure)
+
+    click_on(I18n.t("tab.databases"))
+
+    within(".nav-tabs") do
+      expect(page).to have_content("Databases")
+    end
+
+    within("dl") do
+      expect(page).to have_content("Identifier")
+      expect(page).to have_content("bikeshed")
+
+      expect(page).to have_content("Name")
+      expect(page).to have_content("db.t2.small")
+
+      expect(page).to have_content("Engine")
+      expect(page).to have_content("mysql")
+
+      expect(page).to have_content("Engine version")
+      expect(page).to have_content("5.7.26")
+
+      expect(page).to have_content("Instance class")
+      expect(page).to have_content("bikeshed")
+    end
+
+    within("#connect-steps") do
+      expect(page).to have_content(I18n.t("database.connect.step.1").html_safe)
+      expect(page).to have_content(I18n.t("database.connect.step.2").html_safe)
+      expect(page).to have_content(I18n.t("database.connect.step.3"))
+    end
+
+    within("#staging-snippet") do
+      expect(page).to have_content("dalmatian rds shell -i test-app -e staging -r bikeshed")
+    end
+
+    within("#production-snippet") do
+      expect(page).to have_content("dalmatian rds shell -i test-app -e production -r bikeshed")
+    end
+  end
+end


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

Users can see a new "databases" tab and from there are steered into how to create a direct connection to a given instance from their machine.

We currently only have 1 RDS instance per infrastructure which is replicated over environments. Since RDS is an array in Dalmatian config we support the fact that this can be multiple, though the view hasn't been styled for this case so it might look a bit busy and need more work later.

We imagine that we could iterate this next by adding links that automatically open an AWS web page with a session running in the browser.

## Screenshots of UI changes

![Screenshot 2020-11-13 at 11 14 28](https://user-images.githubusercontent.com/912473/99066783-6b97b980-25a1-11eb-89e9-1c119a37c512.png)
