### PR TITLE
Fix instructions for generating MFA tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,10 @@ Due to risks associated with the high level of access, this service is designed 
 
 Once a member of the ops team has created you an AWS user on Dalmatian you should be able to [follow these instructions to set your machine up with AWS permissions](https://github.com/dxw/dalmatian-developer-docs/blob/master/setting-up-aws-credentials-on-your-local-environment.md). Ensure you have a local `AWS_PROFILE` named `dalmatian-admin`.
 
-Every 12 hours you will need to [renew your local MFA token by following these instructions](https://github.com/dxw/dalmatian-tools) before starting the server.
+**Every 12 hours** you will need to renew your local MFA token by following these instructions before starting the server:
 
-```
-cd dalmatian-tools
-dalmatian-mfa -m <an active AWS 2FA token for your AWS login>
+```bash
+$ bin/dalmatian-mfa -m <an active AWS 2FA token for your AWS login>
 ```
 
 ## Getting started

--- a/bin/dalmatian-mfa
+++ b/bin/dalmatian-mfa
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+# exit on failures
+set -e
+set -o pipefail
+
+usage() {
+  echo "Usage: $(basename "$0") [OPTIONS]" 1>&2
+  echo "  -h               - help"
+  echo "  -m <mfa_code>    - MFA code (required)"
+  echo "  -p <profile>     - AWS profile name (defaults to \$AWS_PROFILE or"
+  echo "                     'default' if that's not set)"
+  echo "  -e               - export to stdout instead of writing the mfa"
+  echo "                     credentials to ~/.aws/credentials"
+  exit 1
+}
+
+# if there are no arguments passed exit with usage
+if [ $# -lt 1 ];
+then
+ usage
+fi
+
+AWS_PROFILE=${AWS_PROFILE:-default}
+EXPORT_TO_STDOUT=0
+
+while getopts "m:p:eh" opt;
+do
+  case $opt in
+    m)
+      MFA_CODE=$OPTARG
+      ;;
+    p)
+      AWS_PROFILE=$OPTARG
+      ;;
+    e)
+      EXPORT_TO_STDOUT=1
+      ;;
+    h)
+      usage
+      exit;;
+    *)
+      usage
+      exit;;
+  esac
+done
+
+if [ -z "$MFA_CODE" ];
+then
+  usage
+fi
+
+USERNAME=$(aws sts get-caller-identity --profile "$AWS_PROFILE" | jq -r .Arn | rev | cut -f1 -d'/' | rev)
+MFA_DEVICE=$(aws iam list-mfa-devices --profile "$AWS_PROFILE" --user-name "$USERNAME" | jq -r .MFADevices[0].SerialNumber)
+SESSION_TOKEN_JSON=$(aws sts get-session-token --profile "$AWS_PROFILE" --serial-number "$MFA_DEVICE" --token-code "$MFA_CODE")
+ACCESS_KEY_ID=$(echo "$SESSION_TOKEN_JSON" | jq -r .Credentials.AccessKeyId)
+SECRET_ACCESS_KEY=$(echo "$SESSION_TOKEN_JSON" | jq -r .Credentials.SecretAccessKey)
+SESSION_TOKEN=$(echo "$SESSION_TOKEN_JSON" | jq -r .Credentials.SessionToken)
+
+if [ "$EXPORT_TO_STDOUT" == 1 ];
+then
+  echo "export AWS_ACCESS_KEY_ID=$ACCESS_KEY_ID"
+  echo "export AWS_SECRET_ACCESS_KEY=$SECRET_ACCESS_KEY"
+  echo "export AWS_SESSION_TOKEN=$SESSION_TOKEN"
+else
+  echo "Modifying credentials file..."
+
+  MFA_PROFILE=mfa
+
+  if [ "$AWS_PROFILE" != default ];
+  then
+    MFA_PROFILE="$AWS_PROFILE-mfa"
+  fi
+
+  MFA_LINENUM=$(grep -n "\[$MFA_PROFILE\]" ~/.aws/credentials | cut -f1 -d':' | head -n1 || echo "")
+
+  if [ "$MFA_LINENUM" != "" ];
+  then
+    MFA_LINENUM_END=$((MFA_LINENUM + 4))
+    sed -i '' -e "${MFA_LINENUM},${MFA_LINENUM_END}d" ~/.aws/credentials
+  fi
+
+  {
+    echo "[$MFA_PROFILE]"
+    echo "aws_access_key_id=$ACCESS_KEY_ID"
+    echo "aws_secret_access_key=$SECRET_ACCESS_KEY"
+    echo "aws_session_token=$SESSION_TOKEN"
+  } >> ~/.aws/credentials
+
+  echo "Set credentials for '$MFA_PROFILE'"
+fi


### PR DESCRIPTION
The old MFA binary was changed upstream in Dalmatian Tools with a breaking change: https://github.com/dxw/dalmatian-tools/pull/36 which also changed approach for credential management.

Originally the plan was to try and use the same central Dalmatian tools `dalmatian login` workflow though it was not compatible with this app. See commit for details but essentially AWS CLI (set up script) and the Ruby gem are both trying to load credentials from `~/.aws/*` where they are no longer being placed.

To get this application working without having to have an old version of Dalmatian Tools checkout out locally, we add the old script back into this app so it can be used in isolation from Dalmatian Tools for now.
