### PR TITLE
Don't ignore any dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,30 +6,3 @@ updates:
     interval: daily
     time: "09:00"
     timezone: Etc/Greenwich
-  ignore:
-  - dependency-name: aws-sdk-ssm
-    versions:
-    - 1.103.0
-    - 1.104.0
-    - 1.105.0
-    - 1.106.0
-    - 1.107.0
-  - dependency-name: listen
-    versions:
-    - 3.4.1
-    - 3.5.0
-  - dependency-name: aws-sdk-codepipeline
-    versions:
-    - 1.39.0
-    - 1.40.0
-    - 1.41.0
-    - 1.42.0
-    - 1.43.0
-  - dependency-name: standard
-    versions:
-    - 0.11.0
-    - 0.12.0
-    - 0.13.0
-    - 1.0.0
-    - 1.0.1
-    - 1.0.4


### PR DESCRIPTION
## Changes in this PR
- Removes the ignored dependencies from dependabot's config

The ignore list was created automatically, because there were open PRs created by the now shutdown dependabot-preview.
