### PR TITLE
Fix server startup by requiring Dalmatian tools to authenticate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ## [Unreleased]
 
+- app requires Dalmatian Tools for authenticating with AWS
 - all infrastructures are listed
 - individual infrastructures can be viewed
 - fetch and display environment variables for each service from AWS ParameterStore

--- a/README.md
+++ b/README.md
@@ -8,13 +8,9 @@ Due to risks associated with the high level of access, this service is designed 
 
 ## Prerequisites
 
-Once a member of the ops team has created you an AWS user on Dalmatian you should be able to [follow these instructions to set your machine up with AWS permissions](https://github.com/dxw/dalmatian-developer-docs/blob/master/setting-up-aws-credentials-on-your-local-environment.md). Ensure you have a local `AWS_PROFILE` named `dalmatian-admin`.
-
-**Every 12 hours** you will need to renew your local MFA token by following these instructions before starting the server:
-
-```bash
-$ bin/dalmatian-mfa -m <an active AWS 2FA token for your AWS login>
-```
+This application depends on [Dalmatian
+tools](https://github.com/dxw/dalmatian-tools#installation) being installed and
+used to login into AWS via `dalmatian login`.
 
 ## Getting started
 
@@ -45,11 +41,13 @@ script/console
 ## Static code analysis
 
 Run [Brakeman](https://brakemanscanner.org/) to highlight any security vulnerabilities:
+
 ```bash
 brakeman
 ```
 
 To pipe the results to a file:
+
 ```bash
 brakeman -o report.text
 ```

--- a/lib/aws_client_wrapper.rb
+++ b/lib/aws_client_wrapper.rb
@@ -15,7 +15,8 @@ module AwsClientWrapper
       @role_credentials ||= Aws::AssumeRoleCredentials.new(
         client: core_aws_client,
         role_arn: role_arn,
-        role_session_name: role_session_name
+        role_session_name: role_session_name,
+        external_id: "dalmatian-tools"
       )
     end
 

--- a/script/server
+++ b/script/server
@@ -7,123 +7,25 @@ set -e
 
 cd "$(dirname "$0")/.."
 
+if ! [ "$(command -v dalmatian)" ]
+then
+  echo "Warning: Dalmtian Tools are not installed"
+  echo "         To authenticate with AWS it is required to install and run"
+  echo "         \`dalmatian login\` rather than managing the AWS credentials"
+  echo "         Install from: https://github.com/dxw/dalmatian-tools"
+  exit 1
+fi
+
 echo "==> Updating..."
 script/update
 
 AWS_PROFILE=${AWS_PROFILE:-dalmatian-admin}
 
-if [ "$(command -v dalmatian)" ]
-then
-  if [ -L "$(command -v dalmatian)" ]
-  then
-    DALMATIAN_TOOLS_APP_ROOT="$(dirname "$(dirname "$(readlink "$(command -v dalmatian)")")")"
-  else
-    DALMATIAN_TOOLS_APP_ROOT="$(dirname "$(dirname "$(command -v dalmatian)")")"
-  fi
-  DALMATIAN_CONFIG_STORE="$HOME/.config/dalmatian"
-  DALMATIAN_CONFIG_FILE="$DALMATIAN_CONFIG_STORE/config.json"
-  DALMATIAN_CREDENTIALS_FILE="$DALMATIAN_CONFIG_STORE/credentials.json.enc"
-  DALMATIAN_MFA_CREDENTIALS_FILE="$DALMATIAN_CONFIG_STORE/mfa_credentials.json"
-  DALMATIAN_ASSUME_MAIN_ROLE_CREDENTIALS_FILE="$DALMATIAN_CONFIG_STORE/assume_role_credentials.json"
-  DALMATIAN_CONFIG_JSON_STRING=$(cat "$DALMATIAN_CONFIG_FILE")
-  DALMATIAN_ACCOUNT_ID=$(echo "$DALMATIAN_CONFIG_JSON_STRING" | jq -r '.account_id')
-  DALMATIAN_ROLE=$(echo "$DALMATIAN_CONFIG_JSON_STRING" | jq -r '.dalmatian_role')
-  MFA_CONFIGURED=0
-
-  if [ ! -f "$DALMATIAN_CONFIG_FILE" ]
-  then
-    echo "Warning: You are not logged into Dalmatian"
-    echo "         CTRL^C and use \`dalmatian login\` instead"
-    echo "         Continuing with AWS credentials..."
-  else
-    # If MFA credentials exist, check if they have expired
-    if [ -f "$DALMATIAN_MFA_CREDENTIALS_FILE" ]
-    then
-      DALMATIAN_MFA_CREDENTIALS_JSON_STRING="$(cat "$DALMATIAN_MFA_CREDENTIALS_FILE")"
-      DALMATIAN_MFA_EXPIRATION=$(echo "$DALMATIAN_MFA_CREDENTIALS_JSON_STRING" | jq -r '.aws_session_expiration')
-      DALMATIAN_MFA_EXPIRATION_SECONDS=$(date -j -f "%F T %T %z" "$DALMATIAN_MFA_EXPIRATION" +"%s")
-      EPOCH=$(date +%s)
-      if [ "$DALMATIAN_MFA_EXPIRATION_SECONDS" -lt "$EPOCH" ]
-      then
-        echo "==> MFA credentials expired, requesting new credentials ..."
-      else
-        MFA_CONFIGURED=1
-      fi
-    fi
-
-    # Update MFA credentials if needed
-    if [ "$MFA_CONFIGURED" = "0" ]
-    then
-      DALMATIAN_CREDENTIALS_JSON_STRING=$(
-        gpg --decrypt \
-          --quiet \
-          < "$DALMATIAN_CREDENTIALS_FILE"
-      )
-
-      AWS_ACCESS_KEY_ID="$(echo "$DALMATIAN_CREDENTIALS_JSON_STRING" | jq -r '.aws_access_key_id')"
-      AWS_SECRET_ACCESS_KEY="$(echo "$DALMATIAN_CREDENTIALS_JSON_STRING" | jq -r '.aws_secret_access_key')"
-      AWS_MFA_SECRET="$(echo "$DALMATIAN_CREDENTIALS_JSON_STRING" | jq -r '.aws_mfa_secret')"
-      export AWS_ACCESS_KEY_ID
-      export AWS_SECRET_ACCESS_KEY
-      MFA_CODE="$(oathtool --base32 --totp "$AWS_MFA_SECRET")"
-      "$DALMATIAN_TOOLS_APP_ROOT/bin/aws/mfa" -m "$MFA_CODE"
-    fi
-
-    DALMATIAN_MFA_CREDENTIALS_JSON_STRING="$(cat "$DALMATIAN_MFA_CREDENTIALS_FILE")"
-
-    AWS_ACCESS_KEY_ID=$(echo "$DALMATIAN_MFA_CREDENTIALS_JSON_STRING" | jq -r '.aws_access_key_id')
-    AWS_SECRET_ACCESS_KEY=$(echo "$DALMATIAN_MFA_CREDENTIALS_JSON_STRING" | jq -r '.aws_secret_access_key')
-    AWS_SESSION_TOKEN=$(echo "$DALMATIAN_MFA_CREDENTIALS_JSON_STRING" | jq -r '.aws_session_token')
-
-    export AWS_ACCESS_KEY_ID
-    export AWS_SECRET_ACCESS_KEY
-    export AWS_SESSION_TOKEN
-
-    echo "==> Requesting Assume Role credentials for main Dalmatian account ..."
-    ASSUME_ROLE_RESULT=$(
-      aws sts assume-role \
-      --role-arn "arn:aws:iam::$DALMATIAN_ACCOUNT_ID:role/$DALMATIAN_ROLE" \
-      --role-session-name dalmatian-tools
-    )
-    AWS_ACCESS_KEY_ID=$(echo "$ASSUME_ROLE_RESULT" | jq -r '.Credentials.AccessKeyId')
-    AWS_SECRET_ACCESS_KEY=$(echo "$ASSUME_ROLE_RESULT" | jq -r '.Credentials.SecretAccessKey')
-    AWS_SESSION_TOKEN=$(echo "$ASSUME_ROLE_RESULT" | jq -r '.Credentials.SessionToken')
-
-    export AWS_ACCESS_KEY_ID
-    export AWS_SECRET_ACCESS_KEY
-    export AWS_SESSION_TOKEN
-
-    AWS_SESSION_EXPIRATION=$(echo "$ASSUME_ROLE_RESULT" | jq -r '.Credentials.Expiration' | awk -F':' -v OFS=':' '{ print $1, $2, $3$4 }')
-    DALMATIAN_ASSUME_MAIN_ROLE_CREDENTIALS_JSON_STRING=$(
-      jq -n \
-      --arg aws_access_key_id "$AWS_ACCESS_KEY_ID" \
-      --arg aws_secret_access_key "$AWS_SECRET_ACCESS_KEY" \
-      --arg aws_session_token "$AWS_SESSION_TOKEN" \
-      --arg aws_session_expiration "$AWS_SESSION_EXPIRATION" \
-      '{
-        aws_access_key_id: $aws_access_key_id,
-        aws_secret_access_key: $aws_secret_access_key,
-        aws_session_token: $aws_session_token,
-        aws_session_expiration: $aws_session_expiration
-      }'
-    )
-
-    echo "$DALMATIAN_ASSUME_MAIN_ROLE_CREDENTIALS_JSON_STRING" > "$DALMATIAN_ASSUME_MAIN_ROLE_CREDENTIALS_FILE"
-  fi
-else
-  echo "Warning: Dalmtian Tools are not installed"
-  echo "         It is recommended to install this and run \`dalmatian login\`"
-  echo "         rather than managing the AWS credentials"
-  echo "         Install from: https://github.com/dxw/dalmatian-tools"
-  echo "         Continuing with AWS credentials ..."
-  export AWS_PROFILE
-fi
-
 echo "==> Finding Dalmatian config..."
-CI_PIPELINE=$(aws codepipeline get-pipeline --name ci-terraform-build-pipeline)
+CI_PIPELINE=$(dalmatian aws exec -i test-app codepipeline get-pipeline --name ci-terraform-build-pipeline | sed '/==>/d')
 CI_BUILD_PROJECT_NAME=$(echo "$CI_PIPELINE" | jq -r '.pipeline.stages[] | select(.name == "Build") | .actions[] | select(.name == "Build-ci") | .configuration.ProjectName')
 
-BUILD_PROJECTS=$(aws codebuild batch-get-projects --names "$CI_BUILD_PROJECT_NAME")
+BUILD_PROJECTS=$(dalmatian aws exec -i test-app codebuild batch-get-projects --names "$CI_BUILD_PROJECT_NAME" | sed '/==>/d')
 DALMATIAN_CONFIG_REPO=$(echo "$BUILD_PROJECTS" | jq -r '.projects[0].environment.environmentVariables[] | select(.name == "dalmatian_config_repo") | .value')
 
 echo "==> Fetching Dalmatian config..."
@@ -132,7 +34,7 @@ rm -rf tmp/dalmatian-config
 git clone "$DALMATIAN_CONFIG_REPO" tmp/dalmatian-config
 
 echo "==> Populating the MongoDB with Dalmatian config..."
-bundle exec rake populate_database
+dalmatian util exec -i test-app bundle exec rake populate_database
 
 echo "==> Starting the development server..."
-bundle exec rails server
+dalmatian util exec -i test-app bundle exec rails server

--- a/spec/support/aws_api_helpers.rb
+++ b/spec/support/aws_api_helpers.rb
@@ -119,7 +119,8 @@ module AwsApiHelpers
     allow(Aws::AssumeRoleCredentials).to receive(:new).with(
       client: aws_sts_client,
       role_arn: "arn:aws:iam::#{account_id}:role/#{ENV["AWS_ROLE"]}",
-      role_session_name: "role_session_name"
+      role_session_name: "role_session_name",
+      external_id: "dalmatian-tools"
     ).and_return(credentials)
 
     aws_ssm_client = instance_double(Aws::SSM::Client)
@@ -145,7 +146,8 @@ module AwsApiHelpers
     allow(Aws::AssumeRoleCredentials).to receive(:new).with(
       client: stub_aws_sts_client,
       role_arn: "arn:aws:iam::#{infrastructure.account_id}:role/#{ENV["AWS_ROLE"]}",
-      role_session_name: "role_session_name"
+      role_session_name: "role_session_name",
+      external_id: "dalmatian-tools"
     ).and_return(credentials)
 
     aws_code_pipeline_client = instance_double(Aws::CodePipeline::Client)


### PR DESCRIPTION
The start script had become out of date and didn't work to authenticate properly for AWS. Making the app completely unusable.

Dalmatian Tools [1] is now more stable and feature rich. It is the single place that is being actively worked on so it makes sense to try to reuse it and having a single definition for local authenticattion with AWS.

In terms of changes to the start script we use 2 bits of magic from Dalmatian Tools:

1. Whenever we use the `dalmatian` binary it calls the bin/aws/assume-infrastructure-role script [2]. This looks at your local AWS configuration found in `.aws` and/or `.config/dalmatian/` to connect and assume the right AWS role. If you've run `dalmatian login` and gone through that process prior to this, this should work behind the scenes
2. We use `dalmatian util exec` to wrap our commands in a way that includes the necessary environment variables needed for AWS Authentication from within a Rails context: `ENV["AWS_ACCESS_KEY"]` etc.

One note on the use of `dalmatian exec`. Given we pass the output of this to `jq` we have to make sure we strip any comments from it with `sed '/==>/d'`. Every comment should start "==>" so while fragile it should be good enough to hook onto this convention for now.

[1] https://github.com/dxw/dalmatian-tools
[2] https://github.com/dxw/dalmatian-tools/blob/main/bin/dalmatian#L263